### PR TITLE
Fix maven dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,11 +14,18 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
+  <repositories>
+    <repository>
+      <id>cloudera</id>
+      <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+    </repository>
+  </repositories>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-core</artifactId>
-      <version>0.20.2</version>
+      <version>0.20.2-cdh3u6</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
I've got an error while compiling hivemall with maven like below.

It's necessary to use a repository of Cloudera in order to use the jar of CDH in the same way as ant.

```
[ERROR] /Users/jiro/src/hivemall/src/main/hivemall/utils/hadoop/HadoopUtils.java:[55,21] no suitable constructor found f
or Path(java.net.URI)
    constructor org.apache.hadoop.fs.Path.Path(java.lang.String,java.lang.String,java.lang.String) is not applicable
      (actual and formal argument lists differ in length)
    constructor org.apache.hadoop.fs.Path.Path(java.lang.String) is not applicable
      (actual argument java.net.URI cannot be converted to java.lang.String by method invocation conversion)
    constructor org.apache.hadoop.fs.Path.Path(org.apache.hadoop.fs.Path,org.apache.hadoop.fs.Path) is not applicable
      (actual and formal argument lists differ in length)
    constructor org.apache.hadoop.fs.Path.Path(java.lang.String,org.apache.hadoop.fs.Path) is not applicable
      (actual and formal argument lists differ in length)
    constructor org.apache.hadoop.fs.Path.Path(org.apache.hadoop.fs.Path,java.lang.String) is not applicable
      (actual and formal argument lists differ in length)
    constructor org.apache.hadoop.fs.Path.Path(java.lang.String,java.lang.String) is not applicable
      (actual and formal argument lists differ in length)
```
