### PR TITLE
Fix compile error on JDK6

### DIFF
--- a/src/main/hivemall/utils/lang/mutable/MutableInt.java
+++ b/src/main/hivemall/utils/lang/mutable/MutableInt.java
@@ -68,7 +68,7 @@ public final class MutableInt extends Number
 
     @Override
     public int compareTo(MutableInt other) {
-        return Integer.compare(value, other.value);
+        return Integer.valueOf(value).compareTo(other.value);
     }
 
     @Override


### PR DESCRIPTION
Integer.compare(v1, v2) is supported from JDK7. Hive is now supporting JDK6, so Hivemall should also support JDK6.
