### PR TITLE
Excluding asm and asm-parent from dependency to remove a warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,14 @@
 					<groupId>javax.jdo</groupId>
 					<artifactId>jdo2-api</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>asm-parent</groupId>
+					<artifactId>asm-parent</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>asm</groupId>
+					<artifactId>asm</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Signed-off-by: Tsuyoshi Ozawa ozawa.tsuyoshi@gmail.com
