### PR TITLE
Add a initialization script to load jar and ddl

### DIFF
--- a/scripts/misc/init-hivemall.sh
+++ b/scripts/misc/init-hivemall.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/sh
+
+echo "Removing existing hivemall jar"
+hive -e "delete jar hivemall-with-dependencies.jar"
+echo "Adding hivemall jar"
+hive -e "add jar hivemall-with-dependencies.jar"
+echo "Loading hivemall ddl"
+hive -e "source define-all.hive;"
+echo "Succceded to load ddl"


### PR DESCRIPTION
To simplify installation steps described in https://github.com/myui/hivemall/wiki/Installation, I would like to initialization of Hivemall with a initialization script.

With the bundled init-hivemall.sh, the prerequisite and installation steps are simplified as follows

- prerequisite
    - Hive v0.11 or later
    - hivemall-0.3..tar.gz

- installation step

    $ tar xvf hivemall-0.3.tar.gz
    $ cd hivemall-0.3
    $ sh init-hivemall.sh

Any comment would be helpful.
