### PR TITLE
Make hivemall usable in Pig

### DIFF
--- a/scripts/misc/conv_pig.awk
+++ b/scripts/misc/conv_pig.awk
@@ -1,0 +1,15 @@
+BEGIN{ FS=" " }
+{
+    label=$1;
+    features="{"
+    for(i=2;i<=NF;i++)
+    {
+        if (i!=2)
+            features = features ","
+        feature = $i
+        features = features "(" feature ")";
+    }
+    features = features "}"
+    print NR "\t" label "\t" features;
+}
+END{}

--- a/src/main/java/hivemall/ensemble/MaxRowUDAF.java
+++ b/src/main/java/hivemall/ensemble/MaxRowUDAF.java
@@ -58,6 +58,7 @@ public final class MaxRowUDAF extends AbstractGenericUDAFResolver {
     @UDFType(distinctLike = true)
     public static class GenericUDAFMaxRowEvaluator extends GenericUDAFEvaluator {
 
+    	StructObjectInspector inputStructOI;
         ObjectInspector[] inputOIs;
         ObjectInspector[] outputOIs;
 
@@ -91,6 +92,7 @@ public final class MaxRowUDAF extends AbstractGenericUDAFResolver {
                 throws HiveException {
             List<? extends StructField> fields = inputStructOI.getAllStructFieldRefs();
             int length = fields.size();
+            this.inputStructOI = inputStructOI;
             this.inputOIs = new ObjectInspector[length];
             this.outputOIs = new ObjectInspector[length];
 
@@ -149,7 +151,7 @@ public final class MaxRowUDAF extends AbstractGenericUDAFResolver {
             } else if(partial instanceof LazyBinaryStruct) {
                 otherObjects = ((LazyBinaryStruct) partial).getFieldsAsList();
             } else {
-                throw new HiveException("Invalid type: " + partial.getClass().getName());
+            	otherObjects = inputStructOI.getStructFieldsDataAsList(partial);
             }
 
             boolean isMax = false;

--- a/src/main/java/hivemall/ftvec/amplify/AmplifierUDTF.java
+++ b/src/main/java/hivemall/ftvec/amplify/AmplifierUDTF.java
@@ -27,10 +27,11 @@ import java.util.ArrayList;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDTF;
+import org.apache.hadoop.hive.serde2.objectinspector.ConstantObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.WritableConstantIntObjectInspector;
+import org.apache.hadoop.io.IntWritable;
 
 public class AmplifierUDTF extends GenericUDTF {
 
@@ -45,11 +46,11 @@ public class AmplifierUDTF extends GenericUDTF {
         if(!INT_TYPE_NAME.equals(argOIs[0].getTypeName())) {
             throw new UDFArgumentException("first argument must be int: " + argOIs[0].getTypeName());
         }
-        if(!(argOIs[0] instanceof WritableConstantIntObjectInspector)) {
+        if(!(argOIs[0] instanceof ConstantObjectInspector)) {
             throw new UDFArgumentException("WritableConstantIntObjectInspector is expected for the first argument: "
                     + argOIs[0].getClass().getSimpleName());
         }
-        this.xtimes = ((WritableConstantIntObjectInspector) argOIs[0]).getWritableConstantValue().get();
+        this.xtimes = ((IntWritable)((ConstantObjectInspector) argOIs[0]).getWritableConstantValue()).get();
         if(!(xtimes >= 1)) {
             throw new UDFArgumentException("Illegal xtimes value: " + xtimes);
         }

--- a/src/main/java/hivemall/ftvec/amplify/RandomAmplifierUDTF.java
+++ b/src/main/java/hivemall/ftvec/amplify/RandomAmplifierUDTF.java
@@ -32,12 +32,14 @@ import org.apache.hadoop.hive.ql.exec.MapredContext;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDTF;
+import org.apache.hadoop.hive.serde2.objectinspector.ConstantObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils.ObjectInspectorCopyOption;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.WritableConstantIntObjectInspector;
+import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.mapred.JobConf;
 
 public class RandomAmplifierUDTF extends GenericUDTF implements DropoutListener<Object[]> {
@@ -68,11 +70,11 @@ public class RandomAmplifierUDTF extends GenericUDTF implements DropoutListener<
         if(!INT_TYPE_NAME.equals(argOIs[0].getTypeName())) {
             throw new UDFArgumentException("First argument must be int: " + argOIs[0].getTypeName());
         }
-        if(!(argOIs[0] instanceof WritableConstantIntObjectInspector)) {
+        if(!(argOIs[0] instanceof ConstantObjectInspector)) {
             throw new UDFArgumentException("WritableConstantIntObjectInspector is expected for the first argument: "
                     + argOIs[0].getClass().getSimpleName());
         }
-        int xtimes = ((WritableConstantIntObjectInspector) argOIs[0]).getWritableConstantValue().get();
+        int xtimes = ((IntWritable)((ConstantObjectInspector) argOIs[0]).getWritableConstantValue()).get();
         if(!(xtimes >= 1)) {
             throw new UDFArgumentException("Illegal xtimes value: " + xtimes);
         }
@@ -81,11 +83,11 @@ public class RandomAmplifierUDTF extends GenericUDTF implements DropoutListener<
             throw new UDFArgumentException("Second argument must be int: "
                     + argOIs[1].getTypeName());
         }
-        if(!(argOIs[1] instanceof WritableConstantIntObjectInspector)) {
+        if(!(argOIs[1] instanceof ConstantObjectInspector)) {
             throw new UDFArgumentException("WritableConstantIntObjectInspector is expected for the second argument: "
                     + argOIs[1].getClass().getSimpleName());
         }
-        int numBuffers = ((WritableConstantIntObjectInspector) argOIs[1]).getWritableConstantValue().get();
+        int numBuffers = ((IntWritable)((ConstantObjectInspector) argOIs[1]).getWritableConstantValue()).get();
         if(numBuffers < 2) {
             throw new UDFArgumentException("num_buffers must be greater than 2: " + numBuffers);
         }
@@ -104,7 +106,7 @@ public class RandomAmplifierUDTF extends GenericUDTF implements DropoutListener<
         for(int i = 2; i < numArgs; i++) {
             fieldNames.add("c" + (i - 1));
             ObjectInspector rawOI = argOIs[i];
-            ObjectInspector retOI = ObjectInspectorUtils.getStandardObjectInspector(rawOI, ObjectInspectorCopyOption.WRITABLE);
+            ObjectInspector retOI = ObjectInspectorUtils.getStandardObjectInspector(rawOI, ObjectInspectorCopyOption.JAVA);
             fieldOIs.add(retOI);
         }
         return ObjectInspectorFactory.getStandardStructObjectInspector(fieldNames, fieldOIs);

--- a/src/main/java/hivemall/tools/array/ArrayAvgUDAF.java
+++ b/src/main/java/hivemall/tools/array/ArrayAvgUDAF.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.hive.ql.metadata.HiveException;
 
 public final class ArrayAvgUDAF extends UDAF {
 
-    private ArrayAvgUDAF() {}//prevent instantiation
+    public ArrayAvgUDAF() {}
 
     public static class Evaluator implements UDAFEvaluator {
 

--- a/src/main/java/hivemall/utils/hadoop/HiveUtils.java
+++ b/src/main/java/hivemall/utils/hadoop/HiveUtils.java
@@ -35,6 +35,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentTypeException;
 import org.apache.hadoop.hive.serde2.SerDeException;
+import org.apache.hadoop.hive.serde2.io.ByteWritable;
+import org.apache.hadoop.hive.serde2.io.ShortWritable;
 import org.apache.hadoop.hive.serde2.lazy.LazyInteger;
 import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe;
 import org.apache.hadoop.hive.serde2.lazy.LazyString;
@@ -128,7 +130,7 @@ public final class HiveUtils {
             throw new UDFArgumentException("argument must be a constant value: "
                     + TypeInfoUtils.getTypeInfoFromObjectInspector(oi));
         }
-        WritableConstantStringObjectInspector stringOI = (WritableConstantStringObjectInspector) oi;
+        ConstantObjectInspector stringOI = (ConstantObjectInspector) oi;
         return stringOI.getWritableConstantValue().toString();
     }
 
@@ -186,17 +188,17 @@ public final class HiveUtils {
         }
         String typeName = numberOI.getTypeName();
         if(BIGINT_TYPE_NAME.equals(typeName)) {
-            WritableConstantLongObjectInspector longOI = (WritableConstantLongObjectInspector) numberOI;
-            return longOI.getWritableConstantValue().get();
+            ConstantObjectInspector longOI = (ConstantObjectInspector) numberOI;
+            return ((LongWritable)longOI.getWritableConstantValue()).get();
         } else if(INT_TYPE_NAME.equals(typeName)) {
-            WritableConstantIntObjectInspector intOI = (WritableConstantIntObjectInspector) numberOI;
-            return (long) intOI.getWritableConstantValue().get();
+        	ConstantObjectInspector intOI = (ConstantObjectInspector) numberOI;
+            return ((IntWritable) intOI.getWritableConstantValue()).get();
         } else if(SMALLINT_TYPE_NAME.equals(typeName)) {
-            WritableConstantShortObjectInspector shortOI = (WritableConstantShortObjectInspector) numberOI;
-            return (long) shortOI.getWritableConstantValue().get();
+            ConstantObjectInspector shortOI = (ConstantObjectInspector) numberOI;
+            return (long) ((ShortWritable)shortOI.getWritableConstantValue()).get();
         } else if(TINYINT_TYPE_NAME.equals(typeName)) {
-            WritableConstantByteObjectInspector byteOI = (WritableConstantByteObjectInspector) numberOI;
-            return (long) byteOI.getWritableConstantValue().get();
+        	ConstantObjectInspector byteOI = (ConstantObjectInspector) numberOI;
+            return (long) ((ByteWritable)byteOI.getWritableConstantValue()).get();
         }
         throw new UDFArgumentException("Unexpected argument type to cast as long: "
                 + TypeInfoUtils.getTypeInfoFromObjectInspector(numberOI));


### PR DESCRIPTION
There are couple of minor fixes. Mostly because hivemall UDF does not use ObjectInspector passed in but assumes default Hive ObjectInspector. 