### PR TITLE
Added each_top_k UDTF

### DIFF
--- a/scripts/ddl/define-all-as-permanent.hive
+++ b/scripts/ddl/define-all-as-permanent.hive
@@ -424,6 +424,9 @@ CREATE FUNCTION convert_label as 'hivemall.tools.ConvertLabelUDF' USING JAR '${h
 DROP FUNCTION IF EXISTS x_rank;
 CREATE FUNCTION x_rank as 'hivemall.tools.RankSequenceUDF' USING JAR '${hivemall_jar}';
 
+DROP FUNCTION IF EXISTS each_top_k;
+CREATE FUNCTION each_top_k as 'hivemall.tools.EachTopKUDTF' USING JAR '${hivemall_jar}';
+
 ----------------------
 -- string functions --
 ----------------------

--- a/scripts/ddl/define-all-excluding-macro.hive
+++ b/scripts/ddl/define-all-excluding-macro.hive
@@ -420,6 +420,9 @@ create temporary function convert_label as 'hivemall.tools.ConvertLabelUDF';
 drop temporary function x_rank;
 create temporary function x_rank as 'hivemall.tools.RankSequenceUDF';
 
+drop temporary function each_top_k;
+create temporary function each_top_k as 'hivemall.tools.EachTopKUDTF';
+
 ----------------------
 -- string functions --
 ----------------------

--- a/scripts/ddl/define-all-treasuredata.hive
+++ b/scripts/ddl/define-all-treasuredata.hive
@@ -109,6 +109,7 @@ CREATE TEMPORARY FUNCTION jobconf_gets AS 'hivemall.tools.mapred.JobConfGetsUDF'
 CREATE TEMPORARY FUNCTION generate_series AS 'hivemall.tools.GenerateSeriesUDTF';
 CREATE TEMPORARY FUNCTION convert_label AS 'hivemall.tools.ConvertLabelUDF';
 CREATE TEMPORARY FUNCTION x_rank AS 'hivemall.tools.RankSequenceUDF';
+CREATE TEMPORARY FUNCTION each_top_k AS 'hivemall.tools.EachTopKUDTF';
 CREATE TEMPORARY FUNCTION isStopword AS 'hivemall.tools.string.StopwordUDF';
 CREATE TEMPORARY FUNCTION is_stopword AS 'hivemall.tools.string.StopwordUDF';
 CREATE TEMPORARY FUNCTION split_words AS 'hivemall.tools.string.SplitWordsUDF';

--- a/scripts/ddl/define-all.hive
+++ b/scripts/ddl/define-all.hive
@@ -420,6 +420,9 @@ create temporary function convert_label as 'hivemall.tools.ConvertLabelUDF';
 drop temporary function x_rank;
 create temporary function x_rank as 'hivemall.tools.RankSequenceUDF';
 
+drop temporary function each_top_k;
+create temporary function each_top_k as 'hivemall.tools.EachTopKUDTF';
+
 ----------------------
 -- string functions --
 ----------------------

--- a/scripts/ddl/treasuredata.ddl
+++ b/scripts/ddl/treasuredata.ddl
@@ -145,6 +145,7 @@
       @ddl.create_function("generate_series", "hivemall.tools.GenerateSeriesUDTF")
       @ddl.create_function("convert_label", "hivemall.tools.ConvertLabelUDF")
       @ddl.create_function("x_rank", "hivemall.tools.RankSequenceUDF")
+      @ddl.create_function("each_top_k", "hivemall.tools.EachTopKUDTF")
 
       # String functions
       @ddl.create_function("isStopword", "hivemall.tools.string.StopwordUDF")

--- a/src/main/java/hivemall/tools/EachTopKUDTF.java
+++ b/src/main/java/hivemall/tools/EachTopKUDTF.java
@@ -1,0 +1,213 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2015 Makoto YUI
+ * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hivemall.tools;
+
+import hivemall.utils.collections.BoundedPriorityQueue;
+import hivemall.utils.hadoop.HiveUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDTF;
+import org.apache.hadoop.hive.serde2.io.DoubleWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils.ObjectInspectorCopyOption;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
+import org.apache.hadoop.io.IntWritable;
+
+@Description(name = "each_top_k", value = "_FUNC_(const int K, Object group, double cmpKey, *) - Returns top-K values (or tail-K values when k is less than 0)")
+public final class EachTopKUDTF extends GenericUDTF {
+
+    private transient ObjectInspector[] argOIs;
+    private transient ObjectInspector prevGroupOI;
+    private transient PrimitiveObjectInspector cmpKeyOI;
+    private int sizeK;
+
+    private BoundedPriorityQueue<TupleWithKey> queue;
+    private TupleWithKey _tuple;
+    private Object _previousGroup;
+
+    @Override
+    public StructObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
+        final int numArgs = argOIs.length;
+        if(numArgs < 4) {
+            throw new UDFArgumentException("each_top_k(const int K, Object group, double cmpKey, *) takes at least 4 arguments: "
+                    + numArgs);
+        }
+
+        this.argOIs = argOIs;
+        int k = HiveUtils.getAsConstInt(argOIs[0]);
+        if(k == 0) {
+            throw new UDFArgumentException("k should not be 0");
+        }
+        this.prevGroupOI = ObjectInspectorUtils.getStandardObjectInspector(argOIs[1], ObjectInspectorCopyOption.DEFAULT);
+        this.cmpKeyOI = HiveUtils.asDoubleCompatibleOI(argOIs[2]);
+
+        this.sizeK = Math.abs(k);
+        final Comparator<TupleWithKey> comparator;
+        if(k < 0) {
+            comparator = Collections.reverseOrder();
+        } else {
+            comparator = new Comparator<TupleWithKey>() {
+                @Override
+                public int compare(TupleWithKey o1, TupleWithKey o2) {
+                    return o1.compareTo(o2);
+                }
+            };
+        }
+        //this.queue = new BoundedPriorityQueue<Row>(sizeK, Comparator.nullsFirst(comparator));
+        this.queue = new BoundedPriorityQueue<TupleWithKey>(sizeK, comparator);
+        this._tuple = null;
+        this._previousGroup = null;
+
+        final ArrayList<String> fieldNames = new ArrayList<String>(numArgs);
+        final ArrayList<ObjectInspector> fieldOIs = new ArrayList<ObjectInspector>(numArgs);
+        fieldNames.add("rank");
+        fieldOIs.add(PrimitiveObjectInspectorFactory.writableIntObjectInspector);
+        fieldNames.add("key");
+        fieldOIs.add(PrimitiveObjectInspectorFactory.writableDoubleObjectInspector);
+        for(int i = 3; i < numArgs; i++) {
+            fieldNames.add("c" + (i - 2));
+            ObjectInspector rawOI = argOIs[i];
+            ObjectInspector retOI = ObjectInspectorUtils.getStandardObjectInspector(rawOI, ObjectInspectorCopyOption.DEFAULT);
+            fieldOIs.add(retOI);
+        }
+        return ObjectInspectorFactory.getStandardStructObjectInspector(fieldNames, fieldOIs);
+    }
+
+    @Override
+    public void process(Object[] args) throws HiveException {
+        final Object arg1 = args[1];
+        if(isSameGroup(arg1) == false) {
+            Object group = ObjectInspectorUtils.copyToStandardObject(arg1, argOIs[1], ObjectInspectorCopyOption.DEFAULT); // arg1 and group may be null
+            drainQueue();
+            this._previousGroup = group;
+        }
+
+        final double key = PrimitiveObjectInspectorUtils.getDouble(args[2], cmpKeyOI);
+        final Object[] row;
+        TupleWithKey tuple = this._tuple;
+        if(_tuple == null) {
+            row = new Object[args.length - 1];
+            tuple = new TupleWithKey(key, row);
+            this._tuple = tuple;
+        } else {
+            row = tuple.getRow();
+            tuple.setKey(key);
+        }
+        for(int i = 3; i < args.length; i++) {
+            Object arg = args[i];
+            ObjectInspector argOI = argOIs[i];
+            row[i - 1] = ObjectInspectorUtils.copyToStandardObject(arg, argOI, ObjectInspectorCopyOption.DEFAULT);
+        }
+
+        if(queue.offer(tuple)) {
+            this._tuple = null;
+        }
+    }
+
+    private boolean isSameGroup(Object arg1) {
+        if(arg1 == null && _previousGroup == null) {
+            return true;
+        } else if(arg1 == null || _previousGroup == null) {
+            return false;
+        }
+        return ObjectInspectorUtils.compare(arg1, argOIs[1], _previousGroup, prevGroupOI) == 0;
+    }
+
+    private void drainQueue() throws HiveException {
+        final int queueSize = queue.size();
+        if(queueSize > 0) {
+            final TupleWithKey[] tuples = new TupleWithKey[queueSize];
+            for(int i = 0; i < queueSize; i++) {
+                TupleWithKey tuple = queue.poll();
+                if(tuple == null) {
+                    throw new IllegalStateException("Found null element in the queue");
+                }
+                tuples[i] = tuple;
+            }
+            final IntWritable rankProbe = new IntWritable(-1);
+            final DoubleWritable keyProbe = new DoubleWritable(Double.NaN);
+            int rank = 0;
+            double lastKey = Double.NaN;
+            for(int i = queueSize - 1; i >= 0; i--) {
+                TupleWithKey tuple = tuples[i];
+                tuples[i] = null; // help GC
+                double key = tuple.getKey();
+                if(key != lastKey) {
+                    ++rank;
+                    rankProbe.set(rank);
+                    keyProbe.set(key);
+                    lastKey = key;
+                }
+                Object[] row = tuple.getRow();
+                row[0] = rankProbe;
+                row[1] = keyProbe;
+                forward(row);
+            }
+            queue.clear();
+        }
+    }
+
+    @Override
+    public void close() throws HiveException {
+        drainQueue();
+
+        this.queue = null;
+        this._tuple = null;
+    }
+
+    private static final class TupleWithKey implements Comparable<TupleWithKey> {
+        double key;
+        Object[] row;
+
+        TupleWithKey(double key, Object[] row) {
+            this.key = key;
+            this.row = row;
+        }
+
+        double getKey() {
+            return key;
+        }
+
+        Object[] getRow() {
+            return row;
+        }
+
+        void setKey(final double key) {
+            this.key = key;
+        }
+
+        @Override
+        public int compareTo(TupleWithKey o) {
+            return Double.compare(key, o.key);
+        }
+
+    }
+
+}

--- a/src/main/java/hivemall/utils/collections/BoundedPriorityQueue.java
+++ b/src/main/java/hivemall/utils/collections/BoundedPriorityQueue.java
@@ -25,7 +25,7 @@ public final class BoundedPriorityQueue<E> {
         }
         this.maxSize = size;
         this.comparator = comparator;
-        this.queue = new PriorityQueue<E>(comparator);
+        this.queue = new PriorityQueue<E>(size + 10, comparator);
     }
 
     public boolean offer(@Nonnull E e) {

--- a/src/main/java/hivemall/utils/collections/BoundedPriorityQueue.java
+++ b/src/main/java/hivemall/utils/collections/BoundedPriorityQueue.java
@@ -12,11 +12,11 @@ public final class BoundedPriorityQueue<E> {
     @Nonnegative
     private final int maxSize;
     @Nonnull
-    private final Comparator<? super E> comparator;
+    private final Comparator<E> comparator;
     @Nonnull
     private final PriorityQueue<E> queue;
 
-    public BoundedPriorityQueue(int size, @Nonnull Comparator<? super E> comparator) {
+    public BoundedPriorityQueue(int size, @Nonnull Comparator<E> comparator) {
         if(size < 1) {
             throw new IllegalArgumentException("Illegal queue size: " + size);
         }

--- a/src/main/java/hivemall/utils/collections/BoundedPriorityQueue.java
+++ b/src/main/java/hivemall/utils/collections/BoundedPriorityQueue.java
@@ -1,0 +1,66 @@
+package hivemall.utils.collections;
+
+import java.util.Comparator;
+import java.util.PriorityQueue;
+
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public final class BoundedPriorityQueue<E> {
+
+    @Nonnegative
+    private final int maxSize;
+    @Nonnull
+    private final Comparator<? super E> comparator;
+    @Nonnull
+    private final PriorityQueue<E> queue;
+
+    public BoundedPriorityQueue(int size, @Nonnull Comparator<? super E> comparator) {
+        if(size < 1) {
+            throw new IllegalArgumentException("Illegal queue size: " + size);
+        }
+        if(comparator == null) {
+            throw new IllegalArgumentException("comparator should not be null");
+        }
+        this.maxSize = size;
+        this.comparator = comparator;
+        this.queue = new PriorityQueue<E>(comparator);
+    }
+
+    public boolean offer(@Nonnull E e) {
+        if(e == null) {
+            throw new IllegalArgumentException("Null argument is not permitted");
+        }
+        final int numElem = queue.size();
+        if(numElem >= maxSize) {
+            E smallest = queue.peek();
+            final int cmp = comparator.compare(e, smallest);
+            if(cmp < 0) {
+                return false;
+            }
+            queue.poll();
+        }
+        queue.offer(e);
+        return true;
+    }
+
+    @Nullable
+    public E poll() {
+        return queue.poll();
+    }
+
+    @Nullable
+    public E peek() {
+        return queue.peek();
+    }
+
+    public int size() {
+        return queue.size();
+    }
+
+    public void clear() {
+        queue.clear();
+    }
+
+}

--- a/src/main/java/hivemall/utils/hadoop/HiveUtils.java
+++ b/src/main/java/hivemall/utils/hadoop/HiveUtils.java
@@ -20,6 +20,8 @@ package hivemall.utils.hadoop;
 
 import static hivemall.HivemallConstants.BIGINT_TYPE_NAME;
 import static hivemall.HivemallConstants.BOOLEAN_TYPE_NAME;
+import static hivemall.HivemallConstants.DOUBLE_TYPE_NAME;
+import static hivemall.HivemallConstants.FLOAT_TYPE_NAME;
 import static hivemall.HivemallConstants.INT_TYPE_NAME;
 import static hivemall.HivemallConstants.SMALLINT_TYPE_NAME;
 import static hivemall.HivemallConstants.STRING_TYPE_NAME;
@@ -40,6 +42,7 @@ import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredObject;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.io.ByteWritable;
+import org.apache.hadoop.hive.serde2.io.DoubleWritable;
 import org.apache.hadoop.hive.serde2.io.ShortWritable;
 import org.apache.hadoop.hive.serde2.lazy.LazyInteger;
 import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe;
@@ -276,6 +279,32 @@ public final class HiveUtils {
             return v.get();
         }
         throw new UDFArgumentException("Unexpected argument type to cast as long: "
+                + TypeInfoUtils.getTypeInfoFromObjectInspector(numberOI));
+    }
+
+    public static double getAsConstDouble(@Nonnull final ObjectInspector numberOI)
+            throws UDFArgumentException {
+        final String typeName = numberOI.getTypeName();
+        if(DOUBLE_TYPE_NAME.equals(typeName)) {
+            DoubleWritable v = getConstValue(numberOI);
+            return v.get();
+        } else if(FLOAT_TYPE_NAME.equals(typeName)) {
+            FloatWritable v = getConstValue(numberOI);
+            return v.get();
+        } else if(INT_TYPE_NAME.equals(typeName)) {
+            IntWritable v = getConstValue(numberOI);
+            return v.get();
+        } else if(BIGINT_TYPE_NAME.equals(typeName)) {
+            LongWritable v = getConstValue(numberOI);
+            return v.get();
+        } else if(SMALLINT_TYPE_NAME.equals(typeName)) {
+            ShortWritable v = getConstValue(numberOI);
+            return v.get();
+        } else if(TINYINT_TYPE_NAME.equals(typeName)) {
+            ByteWritable v = getConstValue(numberOI);
+            return v.get();
+        }
+        throw new UDFArgumentException("Unexpected argument type to cast as double: "
                 + TypeInfoUtils.getTypeInfoFromObjectInspector(numberOI));
     }
 


### PR DESCRIPTION
`each_top_k(int k, ANY group, double value, arg1, arg2, ..., argN)` returns a top-k records for each `group`. It returns a relation consists of `(int rank, double value, arg1, arg2, .., argN)`.

This function is particularly useful for applying a similarity/distance function where the computation complexity is **O(n^m)**.

## Caution
* This UDTF assumes that input records are sorted by `group`. Use `DISTRIBUTED BY group SORTED BY group` to ensure that.
* It takes variable lengths arguments in `argN`. 
* The second argument `value` is used for the comparison.
* If k is less than 0, reverse order is used and `tail-K` records are returned for each `group`.
* Note that this function returns [a pseudo ranking](http://www.michaelpollmeier.com/selecting-top-k-items-from-a-list-efficiently-in-java-groovy/) for top-k. It always returns `at-most K` records for each group. The ranking scheme is similar to `dense_rank` but slightly different in certain cases.

## Usage

```sql
set hivevar:k=10;

SELECT
  each_top_k(
    ${k}, t2.id, angular_similarity(t2.features, t1.features), 
    t2.id, 
    t1.id,  
    t1.y
  ) as (rank, similarity, base_id, neighbor_id, y)
FROM
  test_hivemall t2 
  LEFT OUTER JOIN train_hivemall t1;
```

```
1       0.8594650626182556      12      10514   0
2       0.8585299849510193      12      11719   0
3       0.856602132320404       12      21009   0
4       0.8562054634094238      12      17582   0
5       0.8516314029693604      12      22006   0
6       0.8499397039413452      12      25364   0
7       0.8467264771461487      12      900     0
8       0.8463355302810669      12      8018    0
9       0.8439178466796875      12      7041    0
10      0.8438876867294312      12      21595   0
1       0.8390793800354004      25      21125   0
2       0.8344510793685913      25      14073   0
3       0.8340602517127991      25      9008    0
4       0.8328862190246582      25      6598    0
5       0.8301891088485718      25      943     0
6       0.8271955251693726      25      20400   0
7       0.8255619406700134      25      10922   0
8       0.8241575956344604      25      8477    0
9       0.822281539440155       25      25977   0
10      0.8205751180648804      25      21115   0
1       0.9761330485343933      34      2513    0
2       0.9536819458007812      34      8697    0
3       0.9531533122062683      34      7326    0
4       0.9493276476860046      34      15173   0
5       0.9480557441711426      34      19468   0
...
```

### Custom grouping

```sql
SELECT
  each_top_k(
    10, id1, angular_similarity(features1, features2), 
    id1, 
    id2,  
    y
  ) as (rank, similarity, id, other_id, y)
FROM (
select
  t1.id as id1,
  t2.id as id2,
  t1.features as features1,
  t2.features as features2,
  t1.y
from
  train_hivemall t1
  CROSS JOIN test_hivemall t2
DISTRIBUTE BY id1 SORT BY id1
) t;
```

### Parallelization of similarity computation using WITH clause

```sql
create table similarities
as
WITH test_rnd as (
select
  rand(31) as rnd,
  id,
  features
from
  test_hivemall
),
t01 as (
select
 id,
 features
from
 test_rnd
where
 rnd < 0.2
),
t02 as (
select
 id,
 features
from
 test_rnd
where
 rnd >= 0.2 and rnd < 0.4
),
t03 as (
select
 id,
 features
from
 test_rnd
where
 rnd >= 0.4 and rnd < 0.6
),
t04 as (
select
 id,
 features
from
 test_rnd
where
 rnd >= 0.6 and rnd < 0.8
),
t05 as (
select
 id,
 features
from
 test_rnd
where
 rnd >= 0.8
),
s01 as (
SELECT
  each_top_k(
    10, t2.id, angular_similarity(t2.features, t1.features), 
    t2.id, 
    t1.id,  
    t1.y
  ) as (rank, similarity, base_id, neighbor_id, y)
FROM
  t01 t2 
  LEFT OUTER JOIN train_hivemall t1
),
s02 as (
SELECT
  each_top_k(
    10, t2.id, angular_similarity(t2.features, t1.features), 
    t2.id, 
    t1.id,  
    t1.y
  ) as (rank, similarity, base_id, neighbor_id, y)
FROM
  t02 t2 
  LEFT OUTER JOIN train_hivemall t1
),
s03 as (
SELECT
  each_top_k(
    10, t2.id, angular_similarity(t2.features, t1.features), 
    t2.id, 
    t1.id,  
    t1.y
  ) as (rank, similarity, base_id, neighbor_id, y)
FROM
  t03 t2 
  LEFT OUTER JOIN train_hivemall t1
),
s04 as (
SELECT
  each_top_k(
    10, t2.id, angular_similarity(t2.features, t1.features), 
    t2.id, 
    t1.id,  
    t1.y
  ) as (rank, similarity, base_id, neighbor_id, y)
FROM
  t04 t2 
  LEFT OUTER JOIN train_hivemall t1
),
s05 as (
SELECT
  each_top_k(
    10, t2.id, angular_similarity(t2.features, t1.features), 
    t2.id, 
    t1.id,  
    t1.y
  ) as (rank, similarity, base_id, neighbor_id, y)
FROM
  t05 t2 
  LEFT OUTER JOIN train_hivemall t1
)
select * from s01
union all
select * from s02
union all
select * from s03
union all
select * from s04
union all
select * from s05;
```

### tail-K

```sql
set hivevar:k=-10;

SELECT
  each_top_k(
    ${k}, t2.id, angular_similarity(t2.features, t1.features), 
    t2.id, 
    t1.id,  
    t1.y
  ) as (rank, similarity, base_id, neighbor_id, y)
FROM
  test_hivemall t2 
  LEFT OUTER JOIN train_hivemall t1
-- limit 25
```

```
1       0.4383084177970886      1       7503    0
2       0.44166821241378784     1       10143   0
3       0.4424300789833069      1       11073   0
4       0.44254064559936523     1       17782   0
5       0.4442034363746643      1       18556   0
6       0.45163780450820923     1       3786    0
7       0.45244503021240234     1       10242   0
8       0.4525672197341919      1       21657   0
9       0.4527127146720886      1       17218   0
10      0.45314133167266846     1       25141   0
1       0.44030147790908813     2       3786    0
2       0.4408798813819885      2       23386   0
3       0.44112563133239746     2       11073   0
4       0.4415401816368103      2       22853   0
5       0.4422193765640259      2       21657   0
6       0.4429032802581787      2       10143   0
7       0.4435907006263733      2       24413   0
8       0.44569307565689087     2       7503    0
9       0.4460843801498413      2       25141   0
10      0.4464914798736572      2       24289   0
1       0.43862903118133545     3       23150   1
2       0.4398220181465149      3       9881    1
3       0.44283604621887207     3       27121   0
4       0.4432108402252197      3       26220   1
5       0.44323229789733887     3       18541   0
...
```