### PR TITLE
Migrating from legacy to container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 env:
   global:
    # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created


### PR DESCRIPTION
In order to make CI build efficient, migrate to container-based infrastructure on Travis.
[Migrating from legacy to container-based infrastructure](http://docs.travis-ci.com/user/migrating-from-legacy/)