### PR TITLE
Fix the bugs of accumulator clocks in PartialResult

### DIFF
--- a/src/main/java/hivemall/mix/server/MixServer.java
+++ b/src/main/java/hivemall/mix/server/MixServer.java
@@ -57,7 +57,12 @@ public final class MixServer implements Runnable {
     private final long sessionTTLinSec;
     private final long sweepIntervalInSec;
     private final boolean jmx;
+
     private volatile ServerState state;
+
+    public enum ServerState {
+        INITIALIZING, RUNNING, STOPPING,
+    }
 
     public MixServer(CommandLine cl) {
         this.port = Primitives.parseInt(cl.getOptionValue("port"), DEFAULT_PORT);
@@ -171,9 +176,4 @@ public final class MixServer implements Runnable {
             bossGroup.shutdownGracefully();
         }
     }
-
-    public enum ServerState {
-        INITIALIZING, RUNNING, STOPPING,
-    }
-
 }

--- a/src/main/java/hivemall/mix/server/MixServerHandler.java
+++ b/src/main/java/hivemall/mix/server/MixServerHandler.java
@@ -18,7 +18,6 @@
  */
 package hivemall.mix.server;
 
-import com.google.common.annotations.VisibleForTesting;
 import hivemall.mix.MixMessage;
 import hivemall.mix.MixMessage.MixEventName;
 import hivemall.mix.store.PartialArgminKLD;
@@ -143,7 +142,6 @@ public final class MixServerHandler extends SimpleChannelInboundHandler<MixMessa
      * @param partial accumulator for each feature
      * @return true if sync needed; otherwise false
      */
-    @VisibleForTesting
     public boolean mix(final MixMessage requestMsg, final PartialResult partial) {
         final float weight = requestMsg.getWeight();
         final float covar = requestMsg.getCovariance();

--- a/src/test/java/hivemall/mix/server/MixServerHandlerTest.java
+++ b/src/test/java/hivemall/mix/server/MixServerHandlerTest.java
@@ -1,0 +1,50 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2015 Makoto YUI
+ * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hivemall.mix.server;
+
+import hivemall.mix.MixMessage;
+import hivemall.mix.MixMessage.MixEventName;
+import hivemall.mix.store.PartialAverage;
+import hivemall.mix.store.SessionStore;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MixServerHandlerTest {
+    static final Integer dummyFeature = 0;
+
+    @Test
+    public void MxiWeightTest() {
+        SessionStore session = new SessionStore();
+        MixServerHandler handler = new MixServerHandler(session, 4, 1.0f);
+        PartialAverage acc = new PartialAverage();
+        acc.add(1.0f, 0.0f, (short) 0, 1, 1.0f);
+        MixMessage msg1 = new MixMessage(MixEventName.average, dummyFeature, 3.0f, (short) 4, 1);
+        Assert.assertFalse(handler.mix(msg1, acc));
+        Assert.assertEquals(1, acc.getClock());
+        Assert.assertEquals(2.0, acc.getWeight(1.0f), 0.001);
+        MixMessage msg2 = new MixMessage(MixEventName.average, dummyFeature, 5.0f, (short) 9, 1);
+        Assert.assertTrue(handler.mix(msg2, acc));
+        Assert.assertEquals(2, acc.getClock());
+        Assert.assertEquals(3.0, acc.getWeight(1.0f), 0.001);
+        MixMessage msg3 = new MixMessage(MixEventName.average, dummyFeature, 7.0f, (short) 1, 1);
+        Assert.assertFalse(handler.mix(msg3, acc));
+        Assert.assertEquals(3, acc.getClock());
+        Assert.assertEquals(4.0, acc.getWeight(1.0f), 0.001);
+    }
+}

--- a/src/test/java/hivemall/mix/server/MixServerTest.java
+++ b/src/test/java/hivemall/mix/server/MixServerTest.java
@@ -67,13 +67,11 @@ public class MixServerTest {
                 model.set(feature, new WeightValue(weight));
             }
 
-            waitForMixed(model, 48000, 10000L);
-
-            int numMixed = model.getNumMixed();
-            //System.out.println("number of mix events: " + numMixed);
-            Assert.assertTrue("number of mix events: " + numMixed, numMixed > 0);
-
+            // Block untill the server thread finished
             serverExec.shutdown();
+
+            // No weight synchronization happens for the single MixClient
+            Assert.assertEquals(0, model.getNumMixed());
         } finally {
             IOUtils.closeQuietly(client);
         }
@@ -104,13 +102,11 @@ public class MixServerTest {
                 model.set(feature, new WeightValue(weight));
             }
 
-            waitForMixed(model, 48000, 10000L);
-
-            int numMixed = model.getNumMixed();
-            //System.out.println("number of mix events: " + numMixed);
-            Assert.assertTrue("number of mix events: " + numMixed, numMixed > 0);
-
+            // Block untill the server thread finished
             serverExec.shutdown();
+
+            // No weight synchronization happens for the single MixClient
+            Assert.assertEquals(0, model.getNumMixed());
         } finally {
             IOUtils.closeQuietly(client);
         }
@@ -345,5 +341,4 @@ public class MixServerTest {
             }
         }
     }
-
 }

--- a/src/test/java/hivemall/mix/server/PartialResultTest.java
+++ b/src/test/java/hivemall/mix/server/PartialResultTest.java
@@ -1,0 +1,100 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2015 Makoto YUI
+ * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hivemall.mix.server;
+
+import hivemall.mix.store.PartialResult;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.annotation.Nonnegative;
+
+public class PartialResultTest {
+
+    private class TestPartialResult extends PartialResult {
+
+        @Override
+        public void add(
+                float localWeight, float covar, short clock,
+                @Nonnegative int deltaUpdates,
+                float scale) {}
+
+        @Override
+        public void subtract(
+                float localWeight, float covar,
+                @Nonnegative int deltaUpdates,
+                float scale) {}
+
+        @Override
+        public float getWeight(float scale) {
+            return 0;
+        }
+
+        @Override
+        public float getCovariance(float scale) {
+            return 0;
+        }
+    }
+
+    @Test
+    public void OverflowUnderflowClockTest() {
+        // The clock implementation inside PartialResult depends
+        // on the overflow/underflow beauvoir of short-typed values
+        // in the JVM specification.
+        // Related discussion can be found in a link below;
+        //
+        // How does Java handle integer underflows and overflows and how would you check for it?
+        // - http://stackoverflow.com/questions/3001836/how-does-java-handle-integer-underflows-and-overflows-and-how-would-you-check-fo
+        //
+        short testValue = Short.MAX_VALUE;
+
+        Assert.assertEquals(Short.MIN_VALUE, ++testValue);
+        Assert.assertEquals(Short.MAX_VALUE, --testValue);
+
+        TestPartialResult value1 = new TestPartialResult();
+
+        // Simple test
+        Assert.assertEquals(0, value1.diffClock((short) 0));
+        Assert.assertEquals(3, value1.diffClock((short) 3));
+        Assert.assertEquals(-2, value1.diffClock((short) -2));
+
+        // Freeze clock test
+        Assert.assertEquals(-PartialResult.FREEZE_CLOCK_GAP,
+                value1.diffClock((short) -PartialResult.FREEZE_CLOCK_GAP));
+        Assert.assertEquals(57342,
+                value1.diffClock((short) -(PartialResult.FREEZE_CLOCK_GAP + 1)));
+
+        // Proceed the clock
+        value1.incrClock((short) 12);
+
+        Assert.assertEquals(6, value1.diffClock((short) 18));
+        Assert.assertEquals(0, value1.diffClock((short) 12));
+        Assert.assertEquals(-7, value1.diffClock((short) 5));
+
+        // Overflow test
+        TestPartialResult value2 = new TestPartialResult();
+
+        for (int i = 0; i <= Short.MAX_VALUE; i++) {
+            value2.incrClock((short) 1);
+        }
+
+        Assert.assertEquals(0, value2.diffClock(Short.MIN_VALUE));
+        Assert.assertEquals(1, value2.diffClock((short) (Short.MIN_VALUE + 1)));
+        Assert.assertEquals(-1, value2.diffClock(Short.MAX_VALUE));
+    }
+}


### PR DESCRIPTION
As short-typed clocks overflow in PartialResult, clock comparisons seem to get broken.
This pr mitigates the problem.