### PR TITLE
Add an option for # of mixing threads

### DIFF
--- a/src/main/java/hivemall/mix/server/MixServerArguments.java
+++ b/src/main/java/hivemall/mix/server/MixServerArguments.java
@@ -1,0 +1,97 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2015 Makoto YUI
+ * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hivemall.mix.server;
+
+import hivemall.utils.lang.CommandLineUtils;
+import hivemall.utils.lang.Primitives;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+
+public final class MixServerArguments {
+
+    private final int port;
+    private final int nthreads;
+    private final boolean ssl;
+    private final float scale;
+    private final short syncThreshold;
+    private final long sessionTTLinSec;
+    private final long sweepIntervalInSec;
+    private final boolean jmx;
+
+    public MixServerArguments(String[] args) {
+        this(CommandLineUtils.parseOptions(args, getOptions()));
+    }
+
+    public MixServerArguments(CommandLine cl) {
+        this.port = Primitives.parseInt(cl.getOptionValue("port"), MixServer.DEFAULT_PORT);
+        this.nthreads = Primitives.parseInt(cl.getOptionValue("nthreads"),
+                Runtime.getRuntime().availableProcessors());
+        this.ssl = cl.hasOption("ssl");
+        this.scale = Primitives.parseFloat(cl.getOptionValue("scale"), 1.f);
+        this.syncThreshold = Primitives.parseShort(cl.getOptionValue("sync"), (short) 30);
+        this.sessionTTLinSec = Primitives.parseLong(cl.getOptionValue("ttl"), 120L);
+        this.sweepIntervalInSec = Primitives.parseLong(cl.getOptionValue("sweep"), 60L);
+        this.jmx = cl.hasOption("jmx");
+    }
+
+    static Options getOptions() {
+        Options opts = new Options();
+        opts.addOption("p", "port", true, "port number of the mix server [default: 11212]");
+        opts.addOption("n", "nthreads", true, "#threads for mixing workers [default: #cores]");
+        opts.addOption("ssl", false, "Use SSL for the mix communication [default: false]");
+        opts.addOption("scale", "scalemodel", true, "Scale values of prediction models to avoid overflow [default: 1.0 (no-scale)]");
+        opts.addOption("sync", "sync_threshold", true, "Synchronization threshold using clock difference [default: 30]");
+        opts.addOption("ttl", "session_ttl", true, "The TTL in sec that an idle session lives [default: 120 sec]");
+        opts.addOption("sweep", "session_sweep_interval", true, "The interval in sec that the session expiry thread runs [default: 60 sec]");
+        opts.addOption("jmx", "metrics", false, "Toggle this option to enable monitoring metrics using JMX [default: false]");
+        return opts;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public int getNthreads() {
+        return nthreads;
+    }
+
+    public boolean isSsl() {
+        return ssl;
+    }
+
+    public float getScale() {
+        return scale;
+    }
+
+    public short getSyncThreshold() {
+        return syncThreshold;
+    }
+
+    public long getSessionTTLinSec() {
+        return sessionTTLinSec;
+    }
+
+    public long getSweepIntervalInSec() {
+        return sweepIntervalInSec;
+    }
+
+    public boolean isJmx() {
+        return jmx;
+    }
+}

--- a/src/test/java/hivemall/mix/server/MixServerTest.java
+++ b/src/test/java/hivemall/mix/server/MixServerTest.java
@@ -26,7 +26,6 @@ import hivemall.mix.MixMessage.MixEventName;
 import hivemall.mix.client.MixClient;
 import hivemall.mix.server.MixServer.ServerState;
 import hivemall.utils.io.IOUtils;
-import hivemall.utils.lang.CommandLineUtils;
 import hivemall.utils.net.NetUtils;
 
 import java.util.Random;
@@ -36,18 +35,41 @@ import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nonnegative;
 
-import org.apache.commons.cli.CommandLine;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class MixServerTest {
 
     @Test
+    public void testParseMixServerOptions() {
+        MixServer server1 = new MixServer(new String[] {
+                "-port", Integer.toString(MixServer.DEFAULT_PORT),
+                "-nthreads", "2",
+                "-ssl",
+                "-scale", "3.0",
+                "-sync_threshold", "3",
+                "-ttl", "60",
+                "-sweep", "20",
+                "-jmx",
+        });
+        MixServerArguments options = server1.getOptions();
+        Assert.assertEquals(MixServer.DEFAULT_PORT, options.getPort());
+        Assert.assertEquals(2, options.getNthreads());
+        Assert.assertTrue(options.isSsl());
+        Assert.assertEquals(3.0, options.getScale(), 0.0001);
+        Assert.assertEquals(3, options.getSyncThreshold());
+        Assert.assertEquals(60, options.getSessionTTLinSec());
+        Assert.assertEquals(20, options.getSweepIntervalInSec());
+        Assert.assertTrue(options.isJmx());
+    }
+
+    @Test
     public void testSimpleScenario() throws InterruptedException {
         int port = NetUtils.getAvailablePort();
-        CommandLine cl = CommandLineUtils.parseOptions(new String[] { "-port",
-                Integer.toString(port), "-sync_threshold", "3" }, MixServer.getOptions());
-        MixServer server = new MixServer(cl);
+        MixServer server = new MixServer(new String[] {
+                "-port", Integer.toString(port),
+                "-sync_threshold", "3"
+        });
         ExecutorService serverExec = Executors.newSingleThreadExecutor();
         serverExec.submit(server);
 
@@ -82,9 +104,11 @@ public class MixServerTest {
     @Test
     public void testSSL() throws InterruptedException {
         int port = NetUtils.getAvailablePort();
-        CommandLine cl = CommandLineUtils.parseOptions(new String[] { "-port",
-                Integer.toString(port), "-sync_threshold", "3", "-ssl" }, MixServer.getOptions());
-        MixServer server = new MixServer(cl);
+        MixServer server = new MixServer(new String[] {
+                "-port", Integer.toString(port),
+                "-sync_threshold", "3",
+                "-ssl",
+        });
         ExecutorService serverExec = Executors.newSingleThreadExecutor();
         serverExec.submit(server);
 
@@ -119,9 +143,10 @@ public class MixServerTest {
     @Test
     public void testMultipleClients() throws InterruptedException {
         final int port = NetUtils.getAvailablePort();
-        CommandLine cl = CommandLineUtils.parseOptions(new String[] { "-port",
-                Integer.toString(port), "-sync_threshold", "3" }, MixServer.getOptions());
-        MixServer server = new MixServer(cl);
+        MixServer server = new MixServer(new String[] {
+                "-port", Integer.toString(port),
+                "-sync_threshold", "3",
+        });
         ExecutorService serverExec = Executors.newSingleThreadExecutor();
         serverExec.submit(server);
 
@@ -175,9 +200,10 @@ public class MixServerTest {
     @Test
     public void test2ClientsZeroOneSparseModel() throws InterruptedException {
         final int port = NetUtils.getAvailablePort();
-        CommandLine cl = CommandLineUtils.parseOptions(new String[] { "-port",
-                Integer.toString(port), "-sync_threshold", "30" }, MixServer.getOptions());
-        MixServer server = new MixServer(cl);
+        MixServer server = new MixServer(new String[] {
+                "-port", Integer.toString(port),
+                "-sync_threshold", "30",
+        });
         ExecutorService serverExec = Executors.newSingleThreadExecutor();
         serverExec.submit(server);
 
@@ -204,9 +230,10 @@ public class MixServerTest {
     @Test
     public void test2ClientsZeroOneDenseModel() throws InterruptedException {
         final int port = NetUtils.getAvailablePort();
-        CommandLine cl = CommandLineUtils.parseOptions(new String[] { "-port",
-                Integer.toString(port), "-sync_threshold", "30" }, MixServer.getOptions());
-        MixServer server = new MixServer(cl);
+        MixServer server = new MixServer(new String[] {
+                "-port", Integer.toString(port),
+                "-sync_threshold", "30",
+        });
         ExecutorService serverExec = Executors.newSingleThreadExecutor();
         serverExec.submit(server);
 
@@ -233,9 +260,10 @@ public class MixServerTest {
     @Test
     public void test2ClientsZeroOneSparseModelWithMixCanceling() throws InterruptedException {
         final int port = NetUtils.getAvailablePort();
-        CommandLine cl = CommandLineUtils.parseOptions(new String[] { "-port",
-                Integer.toString(port), "-sync_threshold", "30" }, MixServer.getOptions());
-        MixServer server = new MixServer(cl);
+        MixServer server = new MixServer(new String[] {
+                "-port", Integer.toString(port),
+                "-sync_threshold", "30",
+        });
         ExecutorService serverExec = Executors.newSingleThreadExecutor();
         serverExec.submit(server);
 
@@ -262,9 +290,10 @@ public class MixServerTest {
     @Test
     public void test2ClientsZeroOneDenseModelWithMixCanceling() throws InterruptedException {
         final int port = NetUtils.getAvailablePort();
-        CommandLine cl = CommandLineUtils.parseOptions(new String[] { "-port",
-                Integer.toString(port), "-sync_threshold", "30" }, MixServer.getOptions());
-        MixServer server = new MixServer(cl);
+        MixServer server = new MixServer(new String[] {
+                "-port", Integer.toString(port),
+                "-sync_threshold", "30",
+        });
         ExecutorService serverExec = Executors.newSingleThreadExecutor();
         serverExec.submit(server);
 


### PR DESCRIPTION
Some many-core environments implicitly invoke a large number of mixing threads in WorkerGroup, and then may throw some exceptions. This pr adds an option for user-defined #threads.