### PR TITLE
Remove unnecessary codes for shutting down netty applications

### DIFF
--- a/src/main/java/hivemall/mix/client/MixClient.java
+++ b/src/main/java/hivemall/mix/client/MixClient.java
@@ -173,14 +173,13 @@ public final class MixClient implements ModelUpdateHandler, Closeable {
 
     @Override
     public void close() throws IOException {
-        if(workers != null) {
-            for(Channel ch : channelMap.values()) {
-                ch.close();
-            }
-            channelMap.clear();
+        if (initialized) {
+            // We simply shut down the created EventLoopGroups for netty 4.x applications.
+            // http://netty.io/wiki/user-guide-for-4.x.html#wiki-h3-16
             workers.shutdownGracefully();
-            this.workers = null;
+            channelMap.clear();
+            workers = null;
+            initialized = false;
         }
     }
-
 }


### PR DESCRIPTION
ISTM it's ok simply to shut down EventLoopGroup for closing netty applications.
http://netty.io/wiki/user-guide-for-4.x.html#wiki-h3-16