### PR TITLE
Add absent configurations in log4j.properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,12 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+			<version>1.2.17</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>javax.jdo</groupId>
 			<artifactId>jdo2-api</artifactId>
 			<version>2.3-eb</version>

--- a/pom.xml
+++ b/pom.xml
@@ -321,6 +321,7 @@
 								<include>org.apache.hive:hive-serde</include>
 								<include>commons-cli:commons-cli</include>
 								<include>commons-logging:commons-logging</include>
+								<include>log4j:log4j</include>
 								<include>com.google.code.findbugs:jsr305</include>
 								<include>org.apache.hadoop.thirdparty.guava:guava</include>
 							</includes>

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,1 +1,10 @@
-log4j.rootLogger=ERROR
+# Set everything to be logged to the console
+log4j.rootCategory=WARN, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.io.netty=FATAL
+

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,10 +1,10 @@
 # Set everything to be logged to the console
-log4j.rootCategory=WARN, console
+log4j.rootLogger=ERROR, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.err
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
 
 # Settings to quiet third party logs that are too verbose
-log4j.logger.io.netty=FATAL
+log4j.logger.io.netty=ERROR
 


### PR DESCRIPTION
When INFO log-level enabled, error message 'No appenders could be found for logger' appears.
This pr avoids this issue.