### PR TITLE
Fix bugs in PartialResult#diffClock and add tests

### DIFF
--- a/mixserv/src/main/java/hivemall/mix/server/MixServerHandler.java
+++ b/mixserv/src/main/java/hivemall/mix/server/MixServerHandler.java
@@ -130,7 +130,7 @@ public final class MixServerHandler extends SimpleChannelInboundHandler<MixMessa
             if(cancelRequest) {
                 partial.subtract(weight, covar, deltaUpdates, scale);
             } else {
-                short diffClock = partial.diffClock(localClock);
+                int diffClock = partial.diffClock(localClock);
                 partial.add(weight, covar, deltaUpdates, scale);
 
                 if(diffClock >= syncThreshold) {// sync model if clock DIFF is above threshold

--- a/mixserv/src/main/java/hivemall/mix/store/PartialResult.java
+++ b/mixserv/src/main/java/hivemall/mix/store/PartialResult.java
@@ -61,37 +61,17 @@ public abstract class PartialResult {
         globalClock += deltaUpdates;
     }
 
-    public final short diffClock(short localClock) {
-        int dist = globalClock - localClock;
-        if(dist < 0) {
-            dist = -dist;
-        }
-        final short ret;
-        if(MathUtils.sign(globalClock) == MathUtils.sign(localClock)) {
-            ret = (short) dist;
-        } else {
-            int diff;
-            if(globalClock < 0) {
-                diff = globalClock - Short.MIN_VALUE;
-                assert (diff >= 0) : "diff clock: " + diff + ", globalClock: " + globalClock;
-            } else {
-                diff = Short.MAX_VALUE - globalClock;
-            }
-            if(localClock < 0) {
-                int tmp = localClock - Short.MIN_VALUE;
-                assert (tmp >= 0) : "diff clock: " + tmp + ", localClock: " + localClock;
-                diff += tmp;
-            } else {
-                diff += Short.MAX_VALUE - localClock;
-            }
-            assert (diff >= 0) : diff;
-            if(dist < diff) {
-                ret = (short) dist;
-            } else {
-                ret = (short) diff;
-            }
-        }
-        return ret;
+    // Return diff between global and local clocks.
+    // This implementation depends on the overflow/underflow beauvoir of short-typed values.
+    // i.e., [-32768...l...g...32768) is one of clock examples.
+    // Label 'l' and 'g' represent local and global clocks, respectively.
+    // In this case, it returns a minimum value, l...g or g...l.
+    public final int diffClock(short localClock) {
+        short tempValue1 = globalClock;
+        tempValue1 -= localClock;
+        short tempValue2 = localClock;
+        tempValue2 -= globalClock;
+        return Math.min(Math.abs(tempValue1), Math.abs(tempValue2));
     }
 
 }

--- a/mixserv/src/main/java/hivemall/mix/store/PartialResult.java
+++ b/mixserv/src/main/java/hivemall/mix/store/PartialResult.java
@@ -62,7 +62,7 @@ public abstract class PartialResult {
     }
 
     // Return diff between global and local clocks.
-    // This implementation depends on the overflow/underflow beauvoir of short-typed values.
+    // This implementation depends on the overflow/underflow behavior of short-typed values.
     // i.e., [-32768...l...g...32768) is one of clock examples.
     // Label 'l' and 'g' represent local and global clocks, respectively.
     // In this case, it returns a minimum value, l...g or g...l.

--- a/mixserv/src/test/java/hivemall/mix/server/PartialResultTest.java
+++ b/mixserv/src/test/java/hivemall/mix/server/PartialResultTest.java
@@ -27,7 +27,7 @@ public class PartialResultTest {
     @Test
     public void OverflowUnderflowClockTest() {
         // The clock implementation inside PartialResult depends
-        // on the overflow/underflow beauvoir of short-typed values
+        // on the overflow/underflow behavior of short-typed values
         // in the JVM specification.
         // Related discussion can be found in a link below;
         //

--- a/mixserv/src/test/java/hivemall/mix/server/PartialResultTest.java
+++ b/mixserv/src/test/java/hivemall/mix/server/PartialResultTest.java
@@ -1,0 +1,103 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2015 Makoto YUI
+ * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hivemall.mix.server;
+
+import hivemall.mix.store.PartialResult;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PartialResultTest {
+
+    @Test
+    public void OverflowUnderflowClockTest() {
+        // The clock implementation inside PartialResult depends
+        // on the overflow/underflow beauvoir of short-typed values
+        // in the JVM specification.
+        // Related discussion can be found in a link below;
+        //
+        // How does Java handle integer underflows and overflows and how would you check for it?
+        // - http://stackoverflow.com/questions/3001836/how-does-java-handle-integer-underflows-and-overflows-and-how-would-you-check-fo
+        //
+        short testValue = Short.MAX_VALUE;
+
+        Assert.assertEquals(Short.MIN_VALUE, ++testValue);
+        Assert.assertEquals(Short.MAX_VALUE, --testValue);
+
+        // Initially, clock == 0
+        PartialResult value = new PartialResult() {
+
+            @Override
+            public void add(float localWeight, float covar, int deltaUpdates, float scale) {
+                incrClock(deltaUpdates);
+            }
+
+            @Override
+            public void subtract(float localWeight, float covar, int deltaUpdates, float scale) {}
+
+            @Override
+            public float getWeight(float scale) {
+                return 0.f;
+            }
+
+            @Override
+            public float getCovariance(float scale) {
+                return 0.f;
+            }
+        };
+
+        Assert.assertEquals(0, value.diffClock((short) 0));
+        Assert.assertEquals(3, value.diffClock((short) -3));
+        Assert.assertEquals(2, value.diffClock((short) 2));
+        Assert.assertEquals(32767, value.diffClock(Short.MAX_VALUE));
+        // Max value of PartialResult#diffClock is 32768
+        Assert.assertEquals(32768, value.diffClock(Short.MIN_VALUE));
+        Assert.assertEquals(32767, value.diffClock((short) (Short.MIN_VALUE - 1)));
+
+        // Proceed the clock by 12
+        value.add(0.f, 0.f, 12, 1.f);
+
+        Assert.assertEquals(0, value.diffClock((short) 12));
+        Assert.assertEquals(7, value.diffClock((short) 5));
+        Assert.assertEquals(6, value.diffClock((short) 18));
+        Assert.assertEquals(32767, value.diffClock(
+                addWithUnderOverflow(Short.MAX_VALUE, (short) 12))); // -32757
+        Assert.assertEquals(32768, value.diffClock(
+                addWithUnderOverflow(Short.MAX_VALUE, (short) 13))); // -32756
+        Assert.assertEquals(32767, value.diffClock(
+                addWithUnderOverflow(Short.MAX_VALUE, (short) 14))); // -32755
+
+        // Overflow test
+        value.add(0.f, 0.f, Short.MAX_VALUE, 1.f);
+
+        Assert.assertEquals(0, value.diffClock(
+                addWithUnderOverflow(Short.MAX_VALUE, (short) 12))); // -32757
+        Assert.assertEquals(2, value.diffClock(
+                addWithUnderOverflow(Short.MAX_VALUE, (short) 10))); // -32755
+        Assert.assertEquals(4, value.diffClock(
+                addWithUnderOverflow(Short.MAX_VALUE, (short) 16))); // -32761
+        Assert.assertEquals(32767, value.diffClock((short) 10));
+        Assert.assertEquals(32768, value.diffClock((short) 11));
+        Assert.assertEquals(32767, value.diffClock((short) 12));
+    }
+
+    static short addWithUnderOverflow(short value1, short value2) {
+        value1 += value2;
+        return value1;
+    }
+}


### PR DESCRIPTION
This pr fixes the bugs that occurs when short-typed values overflowed or underflowed.
i.e., the original code returns 32767 if globalClock=0 and localClock=Short.MIN_VALUE.
However, a correct value is 32768.