### PR TITLE
Binarize Label UDTF

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -98,6 +98,24 @@
 			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>1.10.19</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-module-junit4</artifactId>
+			<version>1.6.3</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-api-mockito</artifactId>
+			<version>1.6.3</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/core/src/main/java/hivemall/ftvec/trans/BinarizeLabelUDTF.java
+++ b/core/src/main/java/hivemall/ftvec/trans/BinarizeLabelUDTF.java
@@ -1,0 +1,99 @@
+package hivemall.ftvec.trans;
+
+import java.util.ArrayList;
+
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.UDFType;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDTF;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
+
+@Description(name = "binarize_label",
+        value = "_FUNC_(int/long positive, int/long negative, ...) " +
+                "- Returns positive/negative records that are represented " +
+                "as (..., int label) where label is 0 or 1")
+@UDFType(deterministic = true, stateful = false)
+public class BinarizeLabelUDTF extends GenericUDTF {
+
+    private PrimitiveObjectInspector positiveOI;
+    private PrimitiveObjectInspector negativeOI;
+    private Object[] positiveObjs;
+    private Object[] negativeObjs;
+
+    @Override
+    public StructObjectInspector initialize(ObjectInspector[] argOIs)
+            throws UDFArgumentException {
+        if (argOIs.length < 3) {
+            throw new UDFArgumentException("binalize_label(int/long positive, " +
+                    "int/long negative, *) takes at least three arguments");
+        }
+
+        if (!(argOIs[0] instanceof PrimitiveObjectInspector)) {
+            throw new UDFArgumentException("Expected numeric type but got "
+                    + argOIs[0].getTypeName());
+        }
+
+        if (!(argOIs[1] instanceof PrimitiveObjectInspector)) {
+            throw new UDFArgumentException("Expected numeric type but got "
+                    + argOIs[1].getTypeName());
+        }
+
+        this.positiveOI = (PrimitiveObjectInspector)argOIs[0];
+        this.negativeOI = (PrimitiveObjectInspector)argOIs[1];
+        this.positiveObjs = new Object[argOIs.length - 1];
+        this.negativeObjs = new Object[argOIs.length - 1];
+
+        ArrayList<String> fieldNames = new ArrayList<String>();
+        ArrayList<ObjectInspector> fieldOIs = new ArrayList<ObjectInspector>();
+
+
+        for (int i = 2; i < argOIs.length; i++) {
+            fieldNames.add("c" + (i - 2));
+            // Use negative label ObjectInspector here. OIs for positive
+            // label and negative labels must be same.
+            fieldOIs.add(argOIs[i]);
+        }
+        fieldNames.add("c" + (argOIs.length - 2));
+        fieldOIs.add(PrimitiveObjectInspectorFactory.javaIntObjectInspector);
+
+        return ObjectInspectorFactory
+                .getStandardStructObjectInspector(fieldNames, fieldOIs);
+    }
+
+    @Override
+    public void process(Object[] args) throws HiveException {
+        final Object[] positiveObjs = this.positiveObjs;
+        int positive = PrimitiveObjectInspectorUtils.getInt(args[0], positiveOI);
+        for (int i = 0; i < positiveObjs.length - 1; i++) {
+            positiveObjs[i] = args[i + 2];
+        }
+        // Forward positive label as 0
+        positiveObjs[positiveObjs.length - 1] = 0;
+        for (int i = 0; i < positive; i++) {
+            forward(positiveObjs);
+        }
+
+        final Object[] negativeObjs = this.negativeObjs;
+        int negative = PrimitiveObjectInspectorUtils.getInt(args[1], negativeOI);
+        for (int i = 0; i < negativeObjs.length - 1; i++) {
+            negativeObjs[i] = args[i + 2];
+        }
+        // Forward negative label as 1
+        negativeObjs[negativeObjs.length - 1] = 1;
+        for (int i = 0; i < negative; i++) {
+            forward(negativeObjs);
+        }
+    }
+
+    @Override
+    public void close() throws HiveException {
+        this.positiveObjs = null;
+        this.negativeObjs = null;
+    }
+}

--- a/core/src/test/java/hivemall/ftvec/trans/TestBinarizeLabelUDTF.java
+++ b/core/src/test/java/hivemall/ftvec/trans/TestBinarizeLabelUDTF.java
@@ -1,0 +1,86 @@
+package hivemall.ftvec.trans;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.junit.Test;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.AdditionalMatchers.aryEq;
+import static org.powermock.api.mockito.PowerMockito.doNothing;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.verifyPrivate;
+
+import hivemall.utils.hadoop.WritableUtils;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ BinarizeLabelUDTF.class })
+public class TestBinarizeLabelUDTF {
+    @Test(expected = UDFArgumentException.class)
+    public void testInsufficientLabelColumn() throws HiveException {
+        BinarizeLabelUDTF udtf = new BinarizeLabelUDTF();
+        System.out.println(udtf);
+        ObjectInspector[] argOIs = new ObjectInspector[2];
+        argOIs[0] = PrimitiveObjectInspectorFactory.javaIntObjectInspector;
+        List<String> featureNames = Arrays.asList("positive", "features");
+        argOIs[1] = ObjectInspectorFactory.getStandardConstantListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector, featureNames);
+
+        udtf.initialize(argOIs);
+    }
+
+    @Test
+    public void test2Positive3NegativeSample() throws Exception {
+        BinarizeLabelUDTF udtf = spy(new BinarizeLabelUDTF());
+        System.out.println(udtf);
+        ObjectInspector[] argOIs = new ObjectInspector[3];
+        argOIs[0] = PrimitiveObjectInspectorFactory.javaIntObjectInspector;
+        argOIs[1] = PrimitiveObjectInspectorFactory.javaIntObjectInspector;
+        List<String> featureNames = Arrays.asList("positive", "negative", "features");
+        argOIs[2] = ObjectInspectorFactory.getStandardConstantListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector, featureNames);
+
+        doNothing().when(udtf, "forward", any());
+        udtf.initialize(argOIs);
+
+        Object[] arguments = new Object[3];
+        arguments[0] = new Integer(2);
+        arguments[1] = new Integer(3);
+        arguments[2] = WritableUtils.val("a:1", "b:2");
+        udtf.process(arguments);
+
+        verifyPrivate(udtf, times(5)).invoke("forward", any(Object[].class));
+        verifyPrivate(udtf, times(2)).invoke("forward", aryEq(new Object[] { WritableUtils.val("a:1", "b:2"), 0}));
+        verifyPrivate(udtf, times(3)).invoke("forward", aryEq(new Object[] { WritableUtils.val("a:1", "b:2"), 1}));
+    }
+
+    @Test
+    public void test0Positive0NegativeSample() throws Exception {
+        BinarizeLabelUDTF udtf = spy(new BinarizeLabelUDTF());
+        System.out.println(udtf);
+        ObjectInspector[] argOIs = new ObjectInspector[3];
+        argOIs[0] = PrimitiveObjectInspectorFactory.javaIntObjectInspector;
+        argOIs[1] = PrimitiveObjectInspectorFactory.javaIntObjectInspector;
+        List<String> featureNames = Arrays.asList("positive", "negative", "features");
+        argOIs[2] = ObjectInspectorFactory.getStandardConstantListObjectInspector(
+                PrimitiveObjectInspectorFactory.javaStringObjectInspector, featureNames);
+
+        doNothing().when(udtf, "forward", any());
+        udtf.initialize(argOIs);
+
+        Object[] arguments = new Object[3];
+        arguments[0] = new Integer(0);
+        arguments[1] = new Integer(0);
+        arguments[2] = WritableUtils.val("a:1", "b:2");
+        udtf.process(arguments);
+
+        verifyPrivate(udtf, times(0)).invoke("forward", any(Object[].class));
+    }
+}

--- a/resources/ddl/define-all.hive
+++ b/resources/ddl/define-all.hive
@@ -297,6 +297,9 @@ create temporary function quantified_features as 'hivemall.ftvec.trans.Quantifie
 drop temporary function quantitative_features;
 create temporary function quantitative_features as 'hivemall.ftvec.trans.QuantitativeFeaturesUDF';
 
+drop temporary function binarize_label;
+create temporary function binarize_label as 'hivemall.ftvec.trans.BinarizeLabelUDTF';
+
 --------------------------
 -- ftvec/text functions --
 --------------------------


### PR DESCRIPTION
Expanding numeric labels to actual count of samples can contribute to accuracy improvement in some cases. `binarize_label` explode a record that keeps the count of positive/negative labeled samples into corresponding actual count of samples. For example,

|positive|negative|features|
|:----|:----|:----|
|2|3|"[a:1, b:2]"|

is converted into 

|features|label|
|:----|:----|
|"[a:1, b:2]"|0|
|"[a:1, b:2]"|0|
|"[a:1, b:2]"|1|
|"[a:1, b:2]"|1|
|"[a:1, b:2]"|1|

`binarize_label(int/long positive, int/long negative, ANY arg1, ANY arg2, ..., ANY argN)` 
returns (ANY arg1, ANY arg2, ..., ANY argN, int label) where label is 0 or 1.