### PR TITLE
Add Logarithmic Loss UDAF to evaluation functions

### DIFF
--- a/core/src/main/java/hivemall/evaluation/LogarithmicLossUDAF.java
+++ b/core/src/main/java/hivemall/evaluation/LogarithmicLossUDAF.java
@@ -1,0 +1,103 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2015 Makoto YUI
+ * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hivemall.evaluation;
+
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDAF;
+import org.apache.hadoop.hive.ql.exec.UDAFEvaluator;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.serde2.io.DoubleWritable;
+
+@Description(name = "logloss", value = "_FUNC_(predicted, actual) - Return a Logrithmic Loss")
+public final class LogarithmicLossUDAF extends UDAF {
+
+    public static class Evaluator implements UDAFEvaluator {
+
+        private PartialResult partial;
+
+        public Evaluator() {}
+
+        @Override
+        public void init() {
+            this.partial = null;
+        }
+
+        public boolean iterate(DoubleWritable predicted, DoubleWritable actual)
+                throws HiveException {
+            if(predicted == null || actual == null) {// skip
+                return true;
+            }
+            if(partial == null) {
+                this.partial = new PartialResult();
+            }
+            partial.iterate(predicted.get(), actual.get());
+            return true;
+        }
+
+        public PartialResult terminatePartial() {
+            return partial;
+        }
+
+        public boolean merge(PartialResult other) throws HiveException {
+            if(other == null) {
+                return true;
+            }
+            if(partial == null) {
+                this.partial = new PartialResult();
+            }
+            partial.merge(other);
+            return true;
+        }
+
+        public double terminate() {
+            if(partial == null) {
+                return 0.d;
+            }
+            return partial.getLogLoss();
+        }
+    }
+
+    public static class PartialResult {
+
+        double log_sum;
+        long count;
+
+        PartialResult() {
+            this.log_sum = 0d;
+            this.count = 0L;
+        }
+
+        void iterate(double predicted, double actual) {
+            double epsilon = 1e-15;
+            predicted = Math.max(epsilon, predicted);
+            predicted = Math.min(1-epsilon, predicted);
+            log_sum += actual * Math.log(predicted) + (1-actual) * Math.log(1-predicted);
+            count++;
+        }
+
+        void merge(PartialResult other) {
+            log_sum += other.log_sum;
+            count += other.count;
+        }
+
+        double getLogLoss() { return -1 * log_sum / count; }
+
+    }
+
+}

--- a/resources/ddl/define-all-as-permanent.hive
+++ b/resources/ddl/define-all-as-permanent.hive
@@ -518,6 +518,9 @@ CREATE FUNCTION r2 as 'hivemall.evaluation.R2UDAF' USING JAR '${hivemall_jar}';
 DROP FUNCTION IF EXISTS ndcg;
 CREATE FUNCTION ndcg as 'hivemall.evaluation.NDCGUDAF' USING JAR '${hivemall_jar}';
 
+DROP FUNCTION IF EXISTS logloss;
+CREATE FUNCTION logloss as 'hivemall.evaluation.LogarithmicLossUDAF' USING JAR '${hivemall_jar}';
+
 --------------------------
 -- Matrix Factorization --
 --------------------------

--- a/resources/ddl/define-all.hive
+++ b/resources/ddl/define-all.hive
@@ -514,6 +514,9 @@ create temporary function r2 as 'hivemall.evaluation.R2UDAF';
 drop temporary function ndcg;
 create temporary function ndcg as 'hivemall.evaluation.NDCGUDAF';
 
+drop temporary function logloss;
+create temporary function logloss as 'hivemall.evaluation.LogarithmicLossUDAF';
+
 --------------------------
 -- Matrix Factorization --
 --------------------------


### PR DESCRIPTION
Added a function to calculate Logarithmic Loss for binary classification.

Definition: https://www.kaggle.com/wiki/LogarithmicLoss

This evaluation is used in some competitions on kaggle.
https://www.kaggle.com/c/criteo-display-ad-challenge
https://www.kaggle.com/c/sf-crime