### PR TITLE
[#313] Support seed parameter in rand_amplify_seed

### DIFF
--- a/core/src/main/java/hivemall/HivemallConstants.java
+++ b/core/src/main/java/hivemall/HivemallConstants.java
@@ -24,7 +24,7 @@ public final class HivemallConstants {
 
     public static final String BIAS_CLAUSE = "0";
     public static final int BIAS_CLAUSE_HASHVAL = 0;
-    public static final String CONFKEY_RAND_AMPLIFY_SEED = "hivemall.amplify.seed";
+    public static final long DEFAULT_RAND_AMPLIFY_SEED = 42;
 
     // org.apache.hadoop.hive.serde.Constants (hive 0.9)
     // org.apache.hadoop.hive.serde.serdeConstants (hive 0.10 or later)


### PR DESCRIPTION
see: #313 

In order to specify `seed` parameter not amplified column, we need to implement it as `rand_amplify_seed` separately.