### PR TITLE
Lewuathe support seed in rand amplify seed

### DIFF
--- a/core/src/main/java/hivemall/HivemallConstants.java
+++ b/core/src/main/java/hivemall/HivemallConstants.java
@@ -24,7 +24,6 @@ public final class HivemallConstants {
 
     public static final String BIAS_CLAUSE = "0";
     public static final int BIAS_CLAUSE_HASHVAL = 0;
-    public static final long DEFAULT_RAND_AMPLIFY_SEED = 42;
 
     // org.apache.hadoop.hive.serde.Constants (hive 0.9)
     // org.apache.hadoop.hive.serde.serdeConstants (hive 0.10 or later)

--- a/core/src/main/java/hivemall/HivemallConstants.java
+++ b/core/src/main/java/hivemall/HivemallConstants.java
@@ -24,7 +24,7 @@ public final class HivemallConstants {
 
     public static final String BIAS_CLAUSE = "0";
     public static final int BIAS_CLAUSE_HASHVAL = 0;
-    public static final String CONFKEY_RAND_AMPLIFY_SEED = "hivemall.amplify.seed";
+    public static final long DEFAULT_RAND_AMPLIFY_SEED = 42;
 
     // org.apache.hadoop.hive.serde.Constants (hive 0.9)
     // org.apache.hadoop.hive.serde.serdeConstants (hive 0.10 or later)

--- a/core/src/main/java/hivemall/ftvec/amplify/RandomAmplifierUDTF.java
+++ b/core/src/main/java/hivemall/ftvec/amplify/RandomAmplifierUDTF.java
@@ -18,18 +18,17 @@
  */
 package hivemall.ftvec.amplify;
 
-import hivemall.HivemallConstants;
 import hivemall.UDTFWithOptions;
 import hivemall.common.RandomizedAmplifier;
 import hivemall.common.RandomizedAmplifier.DropoutListener;
 import hivemall.utils.hadoop.HiveUtils;
+import hivemall.utils.lang.Primitives;
 
 import java.util.ArrayList;
+import java.util.List;
 
-import hivemall.utils.lang.Primitives;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
-import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hive.ql.exec.Description;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
@@ -39,13 +38,13 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils.ObjectInspectorCopyOption;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 
-@Description(name = "rand_amplify", value = "_FUNC_(const int xtimes, const int num_buffers, [options], *)"
+@Description(name = "rand_amplify", value = "_FUNC_(const int xtimes [, const string options], *)"
         + " - amplify the input records x-times in map-side")
 public final class RandomAmplifierUDTF extends UDTFWithOptions implements DropoutListener<Object[]> {
 
-    private boolean useSeed;
-    private long seed;
-    private boolean hasSeedOption = false;
+    private boolean hasOption = false;
+    private long seed = -1L;
+    private int numBuffers = 1000;
 
     private transient ObjectInspector[] argOIs;
     private transient RandomizedAmplifier<Object[]> amplifier;
@@ -53,58 +52,48 @@ public final class RandomAmplifierUDTF extends UDTFWithOptions implements Dropou
     @Override
     protected Options getOptions() {
         Options opts = new Options();
-        opts.addOption("seed", true, "Seed value [default value is 42]");
+        opts.addOption("seed", true, "Random seed value [default: -1L (random)]");
+        opts.addOption("buf", "num_buffers", true,
+            "The number of rows to keep in a buffer [default: 1000]");
         return opts;
     }
 
     @Override
     protected CommandLine processOptions(ObjectInspector[] argOIs) throws UDFArgumentException {
         CommandLine cl = null;
-        if (argOIs.length >= 3 && HiveUtils.isConstString(argOIs[2])) {
-            String rawArgs = HiveUtils.getConstString(argOIs[2]);
+        if (argOIs.length >= 3 && HiveUtils.isConstString(argOIs[1])) {
+            String rawArgs = HiveUtils.getConstString(argOIs[1]);
             cl = parseOptions(rawArgs);
-            if (cl.hasOption("seed")) {
-                useSeed = true;
-                hasSeedOption = true;
-                seed = Primitives.parseLong(cl.getOptionValue("seed"), HivemallConstants.DEFAULT_RAND_AMPLIFY_SEED);
-            }
+            this.hasOption = true;
+            this.seed = Primitives.parseLong(cl.getOptionValue("seed"), this.seed);
+            this.numBuffers = Primitives.parseInt(cl.getOptionValue("num_buffers"), this.numBuffers);
         }
-
         return cl;
     }
 
     @Override
     public StructObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
         final int numArgs = argOIs.length;
-        if (numArgs < 3) {
+        if (numArgs < 2) {
             throw new UDFArgumentException(
-                "_FUNC_(int xtimes, int num_buffers, *) takes at least three arguments");
+                "_FUNC_(const int xtimes, [, const string options], *) takes at least two arguments");
         }
         // xtimes
         int xtimes = HiveUtils.getAsConstInt(argOIs[0]);
-        if (!(xtimes >= 1)) {
+        if (xtimes < 1) {
             throw new UDFArgumentException("Illegal xtimes value: " + xtimes);
-        }
-        // num_buffers
-        int numBuffers = HiveUtils.getAsConstInt(argOIs[1]);
-        if (numBuffers < 2) {
-            throw new UDFArgumentException("num_buffers must be greater than 2: " + numBuffers);
         }
         this.argOIs = argOIs;
 
         processOptions(argOIs);
 
-        this.amplifier = useSeed ? new RandomizedAmplifier<Object[]>(numBuffers, xtimes, seed)
-                : new RandomizedAmplifier<Object[]>(numBuffers, xtimes);
+        this.amplifier = (seed == -1L) ? new RandomizedAmplifier<Object[]>(numBuffers, xtimes)
+                : new RandomizedAmplifier<Object[]>(numBuffers, xtimes, seed);
         amplifier.setDropoutListener(this);
 
-        if (useSeed) {
-            LogFactory.getLog(RandomAmplifierUDTF.class).info("rand_amplify() using seed: " + seed);
-        }
-
-        final ArrayList<String> fieldNames = new ArrayList<String>();
-        final ArrayList<ObjectInspector> fieldOIs = new ArrayList<ObjectInspector>();
-        int argStartIndex = hasSeedOption ? 3 : 2;
+        final List<String> fieldNames = new ArrayList<String>();
+        final List<ObjectInspector> fieldOIs = new ArrayList<ObjectInspector>();
+        final int argStartIndex = hasOption ? 2 : 1;
         for (int i = argStartIndex; i < numArgs; i++) {
             fieldNames.add("c" + (i - 1));
             ObjectInspector rawOI = argOIs[i];
@@ -117,7 +106,7 @@ public final class RandomAmplifierUDTF extends UDTFWithOptions implements Dropou
 
     @Override
     public void process(Object[] args) throws HiveException {
-        int argStartIndex = hasSeedOption ? 3 : 2;
+        final int argStartIndex = hasOption ? 2 : 1;
         final Object[] row = new Object[args.length - argStartIndex];
         for (int i = argStartIndex; i < args.length; i++) {
             Object arg = args[i];


### PR DESCRIPTION
```sql
WITH dual as (select 1 as c1, 2 c2)
select rand_amplify(5, '-help', c1, c2) from dual;
```

```
usage: rand_amplify(const int xtimes [, const string options], *) -
       amplify the input records x-times in map-side [-buf <arg>] [-help]
       [-seed <arg>]
 -buf,--num_buffers <arg>   The number of rows to keep in a buffer
                            [default: 1000]
 -help                      Show function help
 -seed <arg>                Random seed value [default: -1L (random)]
```