### PR TITLE
#294 Implement onehot encoding

### DIFF
--- a/core/src/main/java/hivemall/ftvec/OnehotEncodingUDAF.java
+++ b/core/src/main/java/hivemall/ftvec/OnehotEncodingUDAF.java
@@ -1,0 +1,352 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2016 Makoto YUI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hivemall.ftvec;
+
+import hivemall.utils.collections.ComparableList;
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentTypeException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.udf.UDFType;
+import org.apache.hadoop.hive.ql.udf.generic.AbstractGenericUDAFResolver;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFParameterInfo;
+import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
+import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.io.ByteWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.log4j.Logger;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+@Description(name = "onehot_encoding", value = "_FUNC_(feature) - Compute onehot encoded array of given label")
+@UDFType(deterministic = true, stateful = true)
+public class OnehotEncodingUDAF extends AbstractGenericUDAFResolver {
+
+    public static Logger log = Logger.getLogger(OnehotEncodingUDAF.class);
+    public OnehotEncodingUDAF() {
+        super();
+    }
+
+    @Override
+    public GenericUDAFEvaluator getEvaluator(GenericUDAFParameterInfo info) throws SemanticException {
+        return new GenericUDAFOnehotEncodingEvaluator();
+    }
+
+    @Override
+    public GenericUDAFEvaluator getEvaluator(TypeInfo[] parameters) throws SemanticException {
+        int numFeatures = parameters.length;
+        for (int i = 0; i < numFeatures; i++) {
+            if (parameters[i] == null) {
+                throw new UDFArgumentTypeException(i,
+                        "Null type is found. Only primitive type arguments are accepted.");
+            }
+            if (parameters[i].getCategory() != ObjectInspector.Category.PRIMITIVE) {
+                throw new UDFArgumentTypeException(i,
+                        "Only primitive type arguments are accepted but "
+                                + parameters[i].getTypeName() + " was passed as parameter 1.");
+            }
+
+            switch (((PrimitiveTypeInfo) parameters[i]).getPrimitiveCategory()) {
+                case BYTE:
+                case INT:
+                case SHORT:
+                case LONG:
+                case TIMESTAMP:
+                case STRING:
+                    break;
+                default:
+                    throw new UDFArgumentTypeException(i,
+                        "Only integer type or string arguments are accepted but "
+                        + parameters[i].getTypeName() + " was passed as parameter 1.");
+            }
+        }
+
+        return new GenericUDAFOnehotEncodingEvaluator();
+    }
+
+    public static class GenericUDAFOnehotEncodingEvaluator extends GenericUDAFEvaluator {
+        private int numFeatures;
+        private List<String> fieldNames = new ArrayList<String>();
+        private List<ObjectInspector> fieldOIs = new ArrayList<ObjectInspector>();
+        private List<PrimitiveObjectInspector> featureOI = new ArrayList<PrimitiveObjectInspector>();
+        private ListObjectInspector listOI;
+
+        public GenericUDAFOnehotEncodingEvaluator() {
+            // TODO: Configurable number of features.
+            numFeatures = 1;
+        }
+
+        @Override
+        public ObjectInspector init(Mode m, ObjectInspector[] parameters) throws HiveException {
+            super.init(m, parameters);
+
+            if (m == Mode.PARTIAL1 || m == Mode.COMPLETE) {
+                for (int i = 0; i < parameters.length; i++) {
+                    featureOI.add((PrimitiveObjectInspector)parameters[i]);
+                }
+            } else {
+                listOI = (ListObjectInspector)parameters[0];
+            }
+
+            if (m == Mode.PARTIAL1 || m == Mode.PARTIAL2) {
+                return ObjectInspectorFactory.getStandardListObjectInspector(
+                        PrimitiveObjectInspectorFactory.writableByteObjectInspector);
+            } else {
+                for (int i = 0; i < numFeatures; i++) {
+                    fieldNames.add("feature" + String.valueOf(i));
+                }
+                fieldNames.add("encode");
+                for (int i = 0; i < numFeatures; i++) {
+                    fieldOIs.add(PrimitiveObjectInspectorFactory.writableStringObjectInspector);
+                }
+                fieldOIs.add(ObjectInspectorFactory.getStandardListObjectInspector(
+                    PrimitiveObjectInspectorFactory.writableStringObjectInspector
+                ));
+
+                return ObjectInspectorFactory.getStandardListObjectInspector(
+                    ObjectInspectorFactory.getStandardStructObjectInspector(fieldNames, fieldOIs)
+                );
+            }
+        }
+
+        @Override
+        public AggregationBuffer getNewAggregationBuffer() throws HiveException {
+            EncodingBuffer buf = new EncodingBuffer(numFeatures);
+            reset(buf);
+            return buf;
+        }
+
+        @Override
+        public void reset(AggregationBuffer aggregationBuffer) throws HiveException {
+            EncodingBuffer buf = (EncodingBuffer)aggregationBuffer;
+            buf.reset();
+        }
+
+        @Override
+        public void iterate(AggregationBuffer aggregationBuffer, Object[] parameters) throws HiveException {
+            assert(parameters.length == numFeatures);
+            for (int i = 0; i < numFeatures; i++) {
+                if (parameters[i] == null) {
+                    return;
+                }
+            }
+
+            EncodingBuffer buf = (EncodingBuffer)aggregationBuffer;
+            ComparableList<String> featuresList = new ComparableList<String>();
+            for (int i = 0; i < numFeatures; i++) {
+                String s = PrimitiveObjectInspectorUtils.getString(parameters[i], featureOI.get(i));
+                featuresList.add(s);
+            }
+            buf.add(featuresList);
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public Object terminatePartial(AggregationBuffer aggregationBuffer) throws HiveException {
+            EncodingBuffer buf = (EncodingBuffer)aggregationBuffer;
+            return buf.serialize();
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void merge(AggregationBuffer aggregationBuffer, Object partial)
+                throws HiveException {
+            if (partial == null) {
+                return;
+            }
+
+            EncodingBuffer buf = (EncodingBuffer)aggregationBuffer;
+            buf.setNumFeatures(numFeatures);
+            EncodingBuffer partialFeatures = EncodingBuffer.deserialize((List<ByteWritable>)listOI.getList(partial));
+            buf.merge(partialFeatures.getFeaturesSet());
+        }
+
+        @Override
+        public Object terminate(AggregationBuffer aggregationBuffer)
+                throws HiveException {
+            EncodingBuffer buf = (EncodingBuffer)aggregationBuffer;
+
+            return buf.terminate();
+        }
+
+        /**
+         * EncodingBuffer sort all input values with TreeSet and
+         * attach the index for creating one hot encoded vector
+         */
+        static class EncodingBuffer implements AggregationBuffer, Serializable {
+            private final Set<ComparableList<String>> featuresSet;
+            private int numFeatures;
+
+            public EncodingBuffer(int numFeatures) {
+                this.numFeatures = numFeatures;
+                // Labels should be sorted in order to keep index in case of same input
+                this.featuresSet = new TreeSet<ComparableList<String>>();
+            }
+
+            public void setNumFeatures(int numFeatures) {
+                this.numFeatures = numFeatures;
+            }
+
+            public void reset() {
+                featuresSet.clear();
+            }
+
+            public void add(ComparableList<String> features) {
+                featuresSet.add(features);
+            }
+
+            public Set<ComparableList<String>> getFeaturesSet() {
+                return featuresSet;
+            }
+
+            public void merge(Set<ComparableList<String>> partialFeatures) {
+                for (ComparableList<String> features : partialFeatures) {
+                    featuresSet.add(features);
+                }
+            }
+
+            public void merge(List<ComparableList<String>> partialFeatures) {
+                for (List<String> features : partialFeatures) {
+                    featuresSet.add(new ComparableList<String>(features));
+                }
+            }
+
+            public List<ByteWritable> serialize()  {
+                ByteArrayOutputStream b = null;
+                try {
+                    b = new ByteArrayOutputStream();
+                    ObjectOutputStream o = new ObjectOutputStream(b);
+                    o.writeObject(this);
+                } catch (IOException e) {
+                    log.error("Fail to serialize intermediate buffer.");
+                }
+                byte[] byteArray = b.toByteArray();
+                List<ByteWritable> ret = new ArrayList<ByteWritable>();
+                for (int i = 0; i < byteArray.length; i++) {
+                    ret.add(new ByteWritable(byteArray[i]));
+                }
+                return ret;
+            }
+
+            public static EncodingBuffer deserialize(List<ByteWritable> bytes)  {
+                byte[] obj = new byte[bytes.size()];
+                for (int i = 0; i < bytes.size(); i++) {
+                    obj[i] = bytes.get(i).get();
+                }
+                EncodingBuffer buffer = null;
+                try {
+                    ByteArrayInputStream b = new ByteArrayInputStream(obj);
+                    ObjectInputStream o = new ObjectInputStream(b);
+                    buffer = (EncodingBuffer)o.readObject();
+                } catch (IOException e) {
+                    log.error("Fail to deserialize intermediate buffer.", e);
+                } catch (ClassNotFoundException e) {
+                    log.error("Class not found for EncodingBuffer.", e);
+                }
+                return buffer;
+            }
+
+            @SuppressWarnings("unchecked")
+            private List<Text> onehotEncode(ComparableList<String> features, List<Set<String>> uniqueFeatures, int numFeatures) {
+                List<Text> encode = new ArrayList<Text>();
+
+                for (int i = 0; i < numFeatures; i++) {
+                    List<String> uniqueFeatureList = new ArrayList(uniqueFeatures.get(i));
+                    int index = uniqueFeatureList.indexOf(features.get(i));
+                    if (i != 0) {
+                        index += uniqueFeatures.get(i - 1).size();
+                    }
+                    encode.add(new Text(index + ":1"));
+                }
+                return encode;
+            }
+
+            /**
+             * Generate one hot encoding table with given input features.
+             * It generates like
+             *
+             *     category1   | category2
+             *     -------------------------
+             *     cat         | mammal
+             *     dog         | mammal
+             *     human       | mammal
+             *     seahawk     | bird
+             *     wasp        | insect
+             *     wasp        | insect
+             *     cat         | mammal
+             *     dog         | mammal
+             *     human       | mammal
+             *
+             *     is converted to
+             *
+             *     category1   | category2   | encoded_features
+             *     --------------------------------------------
+             *     cat         | mammal      | [1:1, 6:1]     |
+             *     dog         | mammal      | [2:1, 6:1]     |
+             *     human       | mammal      | [3:1, 6:1]     |
+             *     seahawk     | bird        | [4:1, 7:1]     |
+             *     wasp        | insect      | [5:1, 8:1]     |
+             *
+             *   TODO: Only 1 number of features is supported.
+             */
+            public Object terminate() {
+                // Unique values per features
+                List<Set<String>> uniqueFeatures = new ArrayList<Set<String>>();
+
+                // Build unique features which is necessary to obtain encoded index.
+                for (ComparableList<String> features : featuresSet) {
+                    for (int i = 0; i < features.size(); i++) {
+                        if (uniqueFeatures.size() <= i) {
+                            uniqueFeatures.add(i, new TreeSet<String>());
+                        }
+                        uniqueFeatures.get(i).add(features.get(i));
+                    }
+                }
+
+                List<Object[]> ret = new ArrayList<Object[]>();
+                for (ComparableList<String> features : featuresSet) {
+                    // Features + encoding string
+                    Object[] row = new Object[numFeatures + 1];
+                    for (int i = 0; i < numFeatures; i++) {
+                        row[i] = new Text(features.get(i));
+                    }
+                    row[numFeatures] = onehotEncode(features, uniqueFeatures, numFeatures);
+                    ret.add(row);
+                }
+                return ret;
+            }
+        }
+    }
+}

--- a/core/src/main/java/hivemall/utils/collections/ComparableList.java
+++ b/core/src/main/java/hivemall/utils/collections/ComparableList.java
@@ -1,0 +1,64 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2016 Makoto YUI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hivemall.utils.collections;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Comparable list is a class which can be sorted or calculated unique lists.
+ * @param <T>
+ */
+public class ComparableList<T extends Comparable<? super T>>
+        extends LinkedList<T>
+        implements Comparable<ComparableList<T>> {
+
+    public ComparableList() {
+        super();
+    }
+
+    public ComparableList(ComparableList<T> l) {
+        super(l);
+    }
+
+    public ComparableList(List<T> l){
+        super(l);
+    }
+
+    public int compareTo(ComparableList<T> comparableList) {
+        Iterator<T> iterFirst  = iterator();
+        Iterator<T> iterSecond = comparableList.iterator();
+        while (iterFirst.hasNext() && iterSecond.hasNext()) {
+            T   first  = iterFirst .next();
+            T   second = iterSecond.next();
+            int cmp    = first.compareTo(second);
+            if (cmp == 0) {
+                continue;
+            }
+            return cmp;
+        }
+        if (iterFirst.hasNext()) {
+            return 1;
+        }
+        if (iterSecond.hasNext()) {
+            return -1;
+        }
+        return 0;
+    }
+}

--- a/core/src/test/java/hivemall/ftvec/TestOnehotEncodingUDAF.java
+++ b/core/src/test/java/hivemall/ftvec/TestOnehotEncodingUDAF.java
@@ -1,0 +1,199 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2016 Makoto YUI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hivemall.ftvec;
+
+import hivemall.utils.collections.ComparableList;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentTypeException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.StandardListObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.io.Text;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import hivemall.ftvec.OnehotEncodingUDAF.GenericUDAFOnehotEncodingEvaluator;
+import hivemall.ftvec.OnehotEncodingUDAF.GenericUDAFOnehotEncodingEvaluator.EncodingBuffer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ OnehotEncodingUDAF.class })
+public class TestOnehotEncodingUDAF {
+    EncodingBuffer buffer = null;
+    @Before
+    public void setup() {
+        buffer = new EncodingBuffer(2);
+        buffer.reset();
+    }
+
+    @After
+    public void shutdown() {
+        buffer.reset();
+    }
+
+    @Test
+    public void testEncodingBufferSize() {
+        ComparableList<String> features1 = new ComparableList<String>();
+        features1.add("human");
+        features1.add("mammal");
+        buffer.add(features1);
+        assertEquals(1, buffer.getFeaturesSet().size());
+
+        ComparableList<String> features2 = new ComparableList<String>();
+        features2.add("dog");
+        features2.add("mammal");
+        buffer.add(features2);
+        assertEquals(2, buffer.getFeaturesSet().size());
+
+        ComparableList<String> features3 = new ComparableList<String>();
+        features3.add("dog");
+        features3.add("mammal");
+        buffer.add(features3);
+        assertEquals(2, buffer.getFeaturesSet().size());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testEncodeFromBuffer() {
+        ComparableList<String> features1 = new ComparableList<String>();
+        features1.add("human");
+        features1.add("mammal");
+        buffer.add(features1);
+        ComparableList<String> features2 = new ComparableList<String>();
+        features2.add("dog");
+        features2.add("mammal");
+        buffer.add(features2);
+        ComparableList<String> features3 = new ComparableList<String>();
+        features3.add("cat");
+        features3.add("mammal");
+        buffer.add(features3);
+        ComparableList<String> features4 = new ComparableList<String>();
+        features4.add("wasp");
+        features4.add("insect");
+        buffer.add(features4);
+        ComparableList<String> features5 = new ComparableList<String>();
+        features5.add("human");
+        features5.add("mammal");
+        buffer.add(features5);
+
+        List<Object[]> ret = (List<Object[]>)buffer.terminate();
+        assertEquals(4, ret.size());
+        for (Object[] encode : ret) {
+            assertEquals(3, encode.length);
+        }
+        // Check encoding of A
+        Object[] encodedA = ret.get(0);
+        assertEquals(new Text("cat"), encodedA[0]);
+        assertEquals(new Text("mammal"), encodedA[1]);
+        ArrayList<String> encode = (ArrayList<String>)encodedA[2];
+        assertEquals(2, encode.size());
+        assertEquals(new Text("0:1"), encode.get(0));
+        assertEquals(new Text("5:1"), encode.get(1));
+
+        // Check encoding of A
+        Object[] encodedB = ret.get(1);
+        assertEquals(new Text("dog"), encodedB[0]);
+        assertEquals(new Text("mammal"), encodedB[1]);
+        encode = (ArrayList<String>)encodedB[2];
+        assertEquals(2, encode.size());
+        assertEquals(new Text("1:1"), encode.get(0));
+        assertEquals(new Text("5:1"), encode.get(1));
+
+        // Check encoding of A
+        Object[] encodedC = ret.get(2);
+        assertEquals(new Text("human"), encodedC[0]);
+        assertEquals(new Text("mammal"), encodedC[1]);
+        encode = (ArrayList<String>)encodedC[2];
+        assertEquals(2, encode.size());
+        assertEquals(new Text("2:1"), encode.get(0));
+        assertEquals(new Text("5:1"), encode.get(1));
+    }
+
+    @Test
+    public void testResetEncodingBuffer() {
+        ComparableList<String> features1 = new ComparableList<String>();
+        features1.add("human");
+        features1.add("mammal");
+        buffer.add(features1);
+        assertEquals(1, buffer.getFeaturesSet().size());
+        buffer.reset();
+        assertEquals(0, buffer.getFeaturesSet().size());
+    }
+
+    @Test(expected = UDFArgumentTypeException.class)
+    public void testGetEvaluatorOverParameter() throws SemanticException {
+        OnehotEncodingUDAF udaf = new OnehotEncodingUDAF();
+        TypeInfo[] parameters = new TypeInfo[2];
+        udaf.getEvaluator(parameters);
+    }
+
+    @Test(expected = UDFArgumentTypeException.class)
+    public void testGetEvaluatorWithNonPrimitiveParams() throws SemanticException {
+        OnehotEncodingUDAF udaf = new OnehotEncodingUDAF();
+        ListTypeInfo[] parameters = new ListTypeInfo[1];
+        parameters[0] = new ListTypeInfo();
+        parameters[0].setListElementTypeInfo(new PrimitiveTypeInfo());
+        udaf.getEvaluator(parameters);
+    }
+
+    @Test(expected = UDFArgumentTypeException.class)
+    public void testGetEvaluatorWithDouble() throws SemanticException {
+        OnehotEncodingUDAF udaf = new OnehotEncodingUDAF();
+        TypeInfo[] parameters = new TypeInfo[1];
+        parameters[0] = new PrimitiveTypeInfo();
+        ((PrimitiveTypeInfo)parameters[0]).setTypeName("double");
+        udaf.getEvaluator(parameters);
+    }
+
+    @Test
+    public void testEvaluatorPartialOutput() throws HiveException {
+        GenericUDAFOnehotEncodingEvaluator evaluator = new GenericUDAFOnehotEncodingEvaluator();
+        GenericUDAFEvaluator.Mode m = GenericUDAFEvaluator.Mode.PARTIAL1;
+        ObjectInspector[] parameters = new ObjectInspector[1];
+        parameters[0] = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+        ObjectInspector ret = evaluator.init(m, parameters);
+        assertTrue(ret instanceof StandardListObjectInspector);
+    }
+
+    @Test
+    public void testEvaluatorFinalOutput() throws HiveException {
+        GenericUDAFOnehotEncodingEvaluator evaluator = new GenericUDAFOnehotEncodingEvaluator();
+        GenericUDAFEvaluator.Mode m = GenericUDAFEvaluator.Mode.FINAL;
+        ObjectInspector[] parameters = new ObjectInspector[1];
+        parameters[0] = ObjectInspectorFactory.getStandardListObjectInspector(
+                PrimitiveObjectInspectorFactory.writableIntObjectInspector
+        );
+        ObjectInspector ret = evaluator.init(m, parameters);
+        assertTrue(ret instanceof StandardListObjectInspector);
+    }
+}

--- a/core/src/test/java/hivemall/utils/collections/ComparableListTest.java
+++ b/core/src/test/java/hivemall/utils/collections/ComparableListTest.java
@@ -1,0 +1,63 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2016 Makoto YUI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hivemall.utils.collections;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
+
+public class ComparableListTest {
+    @Test
+    public void testUniqueListInSet() {
+        ComparableList<String> l1 = new ComparableList<String>();
+        l1.add("A");
+        l1.add("B");
+        l1.add("C");
+        ComparableList<String> l2 = new ComparableList<String>();
+        l2.add("A");
+        l2.add("B");
+        l2.add("C");
+
+        Set<ComparableList<String>> s = new HashSet<ComparableList<String>>();
+        s.add(l1);
+        s.add(l2);
+
+        Assert.assertEquals(1, s.size());
+    }
+
+    @Test
+    public void testSortedListInSet() {
+        ComparableList<String> l1 = new ComparableList<String>();
+        l1.add("A");
+        l1.add("B");
+        l1.add("C");
+        ComparableList<String> l2 = new ComparableList<String>();
+        l2.add("A");
+        l2.add("B");
+        l2.add("D");
+
+        Set<ComparableList<String>> s = new TreeSet<ComparableList<String>>();
+        s.add(l1);
+        s.add(l2);
+
+        Assert.assertEquals(2, s.size());
+    }
+}

--- a/resources/ddl/define-all.hive
+++ b/resources/ddl/define-all.hive
@@ -229,6 +229,9 @@ create temporary function feature as 'hivemall.ftvec.FeatureUDF';
 drop temporary function feature_index;
 create temporary function feature_index as 'hivemall.ftvec.FeatureIndexUDF';
 
+drop temporary function onehot_encoding;
+create temporary function onehot_encoding as 'hivemall.ftvec.OnehotEncodingUDAF';
+
 ----------------------------------
 -- feature converting functions --
 ----------------------------------

--- a/resources/ddl/define-udfs.td.hql
+++ b/resources/ddl/define-udfs.td.hql
@@ -76,6 +76,7 @@ create temporary function bpr_sampling as 'hivemall.ftvec.ranking.BprSamplingUDT
 create temporary function item_pairs_sampling as 'hivemall.ftvec.ranking.ItemPairsSamplingUDTF';
 create temporary function populate_not_in as 'hivemall.ftvec.ranking.PopulateNotInUDTF';
 create temporary function tf as 'hivemall.ftvec.text.TermFrequencyUDAF';
+create temporary function onehot_encoding as 'hivemall.ftvec.OnehotEncodingUDAF';
 create temporary function logress as 'hivemall.regression.LogressUDTF';
 create temporary function train_logistic_regr as 'hivemall.regression.LogressUDTF';
 create temporary function train_pa1_regr as 'hivemall.regression.PassiveAggressiveRegressionUDTF';


### PR DESCRIPTION
see #294 
usage
```sql
SELECT 
  inline(
    onehot_encoding(code)
  )
FROM
  www_access
```

|label|encode|
|:---:|:---:|
|200|[1,0,0]|
|404|[0,1,0]|
|500|[0,0,1]|

We can join onehot encoding table with source table in order to created onehot labeled datas like,

```sql
SELECT 
  source.path,
  source.host,
  encoded.encode
FROM
  www_access source
JOIN (
    SELECT 
      inline(
        onehot_encoding(code)
      )
  FROM
    www_access
) encoded
ON encoded.label = source.code
```
|path|host|encode|
|:---:|:---:|:---|
|/path/to/1|example1.com|[1,0,0]|
|/path/to/2|example2.com|[0,1,0]|