### PR TITLE
Implement additional ranking measures

### DIFF
--- a/core/src/main/java/hivemall/evaluation/AUCUDAF.java
+++ b/core/src/main/java/hivemall/evaluation/AUCUDAF.java
@@ -1,0 +1,228 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2015 Makoto YUI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hivemall.evaluation;
+
+import hivemall.utils.hadoop.HiveUtils;
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentTypeException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.udf.generic.AbstractGenericUDAFResolver;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator.AggregationBuffer;
+import org.apache.hadoop.hive.serde2.io.DoubleWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.*;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.WritableIntObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.io.LongWritable;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Description(
+        name = "auc",
+        value = "_FUNC_(array rankItems, array correctItems [, const int recommendSize = rankItems.size])"
+                + " - Returns AUC")
+public final class AUCUDAF extends AbstractGenericUDAFResolver {
+
+    // prevent instantiation
+    private AUCUDAF() {}
+
+    @Override
+    public GenericUDAFEvaluator getEvaluator(@Nonnull TypeInfo[] typeInfo) throws SemanticException {
+        if (typeInfo.length != 2 && typeInfo.length != 3) {
+            throw new UDFArgumentTypeException(typeInfo.length - 1,
+                "_FUNC_ takes two or three arguments");
+        }
+
+        ListTypeInfo arg1type = HiveUtils.asListTypeInfo(typeInfo[0]);
+        if (!HiveUtils.isPrimitiveTypeInfo(arg1type.getListElementTypeInfo()) &&
+            !HiveUtils.isStructTypeInfo(arg1type.getListElementTypeInfo())) {
+            throw new UDFArgumentTypeException(0,
+                "The first argument `array rankItems` is invalid form: " + typeInfo[0]);
+        }
+        ListTypeInfo arg2type = HiveUtils.asListTypeInfo(typeInfo[1]);
+        if (!HiveUtils.isPrimitiveTypeInfo(arg2type.getListElementTypeInfo())) {
+            throw new UDFArgumentTypeException(1,
+                "The first argument `array rankItems` is invalid form: " + typeInfo[1]);
+        }
+
+        return new Evaluator();
+    }
+
+    public static class Evaluator extends GenericUDAFEvaluator {
+
+        private ListObjectInspector recommendListOI;
+        private ListObjectInspector truthListOI;
+        private WritableIntObjectInspector recommendSizeOI;
+
+        private StructObjectInspector internalMergeOI;
+        private StructField countField;
+        private StructField sumField;
+
+        public Evaluator() {}
+
+        @Override
+        public ObjectInspector init(Mode mode, ObjectInspector[] parameters) throws HiveException {
+            assert (parameters.length == 2 || parameters.length == 3) : parameters.length;
+            super.init(mode, parameters);
+
+            // initialize input
+            if (mode == Mode.PARTIAL1 || mode == Mode.COMPLETE) {// from original data
+                this.recommendListOI = (ListObjectInspector) parameters[0];
+                this.truthListOI = (ListObjectInspector) parameters[1];
+                if (parameters.length == 3) {
+                    this.recommendSizeOI = (WritableIntObjectInspector) parameters[2];
+                }
+            } else {// from partial aggregation
+                StructObjectInspector soi = (StructObjectInspector) parameters[0];
+                this.internalMergeOI = soi;
+                this.countField = soi.getStructFieldRef("count");
+                this.sumField = soi.getStructFieldRef("sum");
+            }
+
+            // initialize output
+            final ObjectInspector outputOI;
+            if (mode == Mode.PARTIAL1 || mode == Mode.PARTIAL2) {// terminatePartial
+                outputOI = internalMergeOI();
+            } else {// terminate
+                outputOI = PrimitiveObjectInspectorFactory.writableDoubleObjectInspector;
+            }
+            return outputOI;
+        }
+
+        private static StructObjectInspector internalMergeOI() {
+            ArrayList<String> fieldNames = new ArrayList<String>();
+            ArrayList<ObjectInspector> fieldOIs = new ArrayList<ObjectInspector>();
+
+            fieldNames.add("sum");
+            fieldOIs.add(PrimitiveObjectInspectorFactory.writableDoubleObjectInspector);
+            fieldNames.add("count");
+            fieldOIs.add(PrimitiveObjectInspectorFactory.writableLongObjectInspector);
+
+            return ObjectInspectorFactory.getStandardStructObjectInspector(fieldNames, fieldOIs);
+        }
+
+        @Override
+        public AggregationBuffer getNewAggregationBuffer() throws HiveException {
+            AggregationBuffer myAggr = new AUCAggregationBuffer();
+            reset(myAggr);
+            return myAggr;
+        }
+
+        @Override
+        public void reset(AggregationBuffer agg) throws HiveException {
+            AUCAggregationBuffer myAggr = (AUCAggregationBuffer) agg;
+            myAggr.reset();
+        }
+
+        @Override
+        public void iterate(AggregationBuffer agg, Object[] parameters) throws HiveException {
+            AUCAggregationBuffer myAggr = (AUCAggregationBuffer) agg;
+
+            List<?> recommendList = recommendListOI.getList(parameters[0]);
+            if (recommendList == null) {
+                recommendList = Collections.emptyList();
+            }
+            List<?> truthList = truthListOI.getList(parameters[1]);
+            if (truthList == null) {
+                return;
+            }
+
+            int recommendSize = recommendList.size();
+            if (parameters.length == 3) {
+                recommendSize = recommendSizeOI.get(parameters[2]);
+            }
+            if (recommendSize < 0 || recommendSize > recommendList.size()) {
+                throw new UDFArgumentException(
+                        "The third argument `int recommendSize` must be in [0, " + recommendList.size() + "]");
+            }
+
+            myAggr.iterate(recommendList, truthList, recommendSize);
+        }
+
+        @Override
+        public Object terminatePartial(AggregationBuffer agg) throws HiveException {
+            AUCAggregationBuffer myAggr = (AUCAggregationBuffer) agg;
+
+            Object[] partialResult = new Object[2];
+            partialResult[0] = new DoubleWritable(myAggr.sum);
+            partialResult[1] = new LongWritable(myAggr.count);
+            return partialResult;
+        }
+
+        @Override
+        public void merge(AggregationBuffer agg, Object partial) throws HiveException {
+            if (partial == null) {
+                return;
+            }
+
+            Object sumObj = internalMergeOI.getStructFieldData(partial, sumField);
+            Object countObj = internalMergeOI.getStructFieldData(partial, countField);
+            double sum = PrimitiveObjectInspectorFactory.writableDoubleObjectInspector.get(sumObj);
+            long count = PrimitiveObjectInspectorFactory.writableLongObjectInspector.get(countObj);
+
+            AUCAggregationBuffer myAggr = (AUCAggregationBuffer) agg;
+            myAggr.merge(sum, count);
+        }
+
+        @Override
+        public DoubleWritable terminate(AggregationBuffer agg) throws HiveException {
+            AUCAggregationBuffer myAggr = (AUCAggregationBuffer) agg;
+            double result = myAggr.get();
+            return new DoubleWritable(result);
+        }
+
+    }
+
+    public static class AUCAggregationBuffer implements AggregationBuffer {
+
+        double sum;
+        long count;
+
+        public AUCAggregationBuffer() {}
+
+        void reset() {
+            this.sum = 0.d;
+            this.count = 0;
+        }
+
+        void merge(double o_sum, long o_count) {
+            sum += o_sum;
+            count += o_count;
+        }
+
+        double get() {
+            if (count == 0) {
+                return 0.d;
+            }
+            return sum / count;
+        }
+
+        void iterate(@Nonnull List<?> recommendList, @Nonnull List<?> truthList, @Nonnull int recommendSize) {
+            sum += BinaryResponsesMeasures.AUC(recommendList, truthList, recommendSize);
+            count++;
+        }
+    }
+
+}

--- a/core/src/main/java/hivemall/evaluation/BinaryResponsesMeasures.java
+++ b/core/src/main/java/hivemall/evaluation/BinaryResponsesMeasures.java
@@ -31,11 +31,12 @@ public final class BinaryResponsesMeasures {
 
     private BinaryResponsesMeasures() {}
 
-    public static double nDCG(@Nonnull final List<?> rankedList, @Nonnull final List<?> groundTruth) {
+    public static double nDCG(@Nonnull final List<?> rankedList, @Nonnull final List<?> groundTruth,
+                              @Nonnull final int recommendSize) {
         double dcg = 0.d;
-        double idcg = IDCG(groundTruth.size());
+        double idcg = IDCG(Math.min(recommendSize, groundTruth.size()));
 
-        for (int i = 0, n = rankedList.size(); i < n; i++) {
+        for (int i = 0, n = recommendSize; i < n; i++) {
             Object item_id = rankedList.get(i);
             if (!groundTruth.contains(item_id)) {
                 continue;

--- a/core/src/main/java/hivemall/evaluation/GradedResponsesMeasures.java
+++ b/core/src/main/java/hivemall/evaluation/GradedResponsesMeasures.java
@@ -1,0 +1,58 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2015 Makoto YUI
+ * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hivemall.evaluation;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * Utility class of various measures.
+ * 
+ * See http://recsyswiki.com/wiki/Discounted_Cumulative_Gain
+ */
+public final class GradedResponsesMeasures {
+
+    private GradedResponsesMeasures() {}
+
+    public static double nDCG(@Nonnull final List<Double> recommendTopRelScoreList,
+                              @Nonnull final List<Double> truthTopRelScoreList,
+                              @Nonnull final int recommendSize) {
+
+        double dcg = DCG(recommendTopRelScoreList, recommendSize);
+        double idcg = DCG(truthTopRelScoreList, recommendSize);
+        return dcg / idcg;
+    }
+
+    /**
+     * Computes DCG
+     * 
+     * @param topRelScoreList ranked list of top relevance scores
+     * @param recommendSize the number of positive items
+     * @return DCG
+     */
+    public static double DCG(final List<Double> topRelScoreList, final int recommendSize) {
+        double dcg = 0.d;
+        for (int i = 0; i < recommendSize; i++) {
+            double relScore = topRelScoreList.get(i);
+            dcg += ((Math.pow(2, relScore) - 1) * Math.log(2)) / Math.log(i + 2);
+        }
+        return dcg;
+    }
+
+}

--- a/core/src/main/java/hivemall/evaluation/MAPUDAF.java
+++ b/core/src/main/java/hivemall/evaluation/MAPUDAF.java
@@ -1,0 +1,228 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2015 Makoto YUI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hivemall.evaluation;
+
+import hivemall.utils.hadoop.HiveUtils;
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentTypeException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.udf.generic.AbstractGenericUDAFResolver;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator.AggregationBuffer;
+import org.apache.hadoop.hive.serde2.io.DoubleWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.*;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.WritableIntObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.io.LongWritable;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Description(
+        name = "average_precision",
+        value = "_FUNC_(array rankItems, array correctItems [, const int recommendSize = rankItems.size])"
+                + " - Returns MAP")
+public final class MAPUDAF extends AbstractGenericUDAFResolver {
+
+    // prevent instantiation
+    private MAPUDAF() {}
+
+    @Override
+    public GenericUDAFEvaluator getEvaluator(@Nonnull TypeInfo[] typeInfo) throws SemanticException {
+        if (typeInfo.length != 2 && typeInfo.length != 3) {
+            throw new UDFArgumentTypeException(typeInfo.length - 1,
+                "_FUNC_ takes two or three arguments");
+        }
+
+        ListTypeInfo arg1type = HiveUtils.asListTypeInfo(typeInfo[0]);
+        if (!HiveUtils.isPrimitiveTypeInfo(arg1type.getListElementTypeInfo()) &&
+            !HiveUtils.isStructTypeInfo(arg1type.getListElementTypeInfo())) {
+            throw new UDFArgumentTypeException(0,
+                "The first argument `array rankItems` is invalid form: " + typeInfo[0]);
+        }
+        ListTypeInfo arg2type = HiveUtils.asListTypeInfo(typeInfo[1]);
+        if (!HiveUtils.isPrimitiveTypeInfo(arg2type.getListElementTypeInfo())) {
+            throw new UDFArgumentTypeException(1,
+                "The first argument `array rankItems` is invalid form: " + typeInfo[1]);
+        }
+
+        return new Evaluator();
+    }
+
+    public static class Evaluator extends GenericUDAFEvaluator {
+
+        private ListObjectInspector recommendListOI;
+        private ListObjectInspector truthListOI;
+        private WritableIntObjectInspector recommendSizeOI;
+
+        private StructObjectInspector internalMergeOI;
+        private StructField countField;
+        private StructField sumField;
+
+        public Evaluator() {}
+
+        @Override
+        public ObjectInspector init(Mode mode, ObjectInspector[] parameters) throws HiveException {
+            assert (parameters.length == 2 || parameters.length == 3) : parameters.length;
+            super.init(mode, parameters);
+
+            // initialize input
+            if (mode == Mode.PARTIAL1 || mode == Mode.COMPLETE) {// from original data
+                this.recommendListOI = (ListObjectInspector) parameters[0];
+                this.truthListOI = (ListObjectInspector) parameters[1];
+                if (parameters.length == 3) {
+                    this.recommendSizeOI = (WritableIntObjectInspector) parameters[2];
+                }
+            } else {// from partial aggregation
+                StructObjectInspector soi = (StructObjectInspector) parameters[0];
+                this.internalMergeOI = soi;
+                this.countField = soi.getStructFieldRef("count");
+                this.sumField = soi.getStructFieldRef("sum");
+            }
+
+            // initialize output
+            final ObjectInspector outputOI;
+            if (mode == Mode.PARTIAL1 || mode == Mode.PARTIAL2) {// terminatePartial
+                outputOI = internalMergeOI();
+            } else {// terminate
+                outputOI = PrimitiveObjectInspectorFactory.writableDoubleObjectInspector;
+            }
+            return outputOI;
+        }
+
+        private static StructObjectInspector internalMergeOI() {
+            ArrayList<String> fieldNames = new ArrayList<String>();
+            ArrayList<ObjectInspector> fieldOIs = new ArrayList<ObjectInspector>();
+
+            fieldNames.add("sum");
+            fieldOIs.add(PrimitiveObjectInspectorFactory.writableDoubleObjectInspector);
+            fieldNames.add("count");
+            fieldOIs.add(PrimitiveObjectInspectorFactory.writableLongObjectInspector);
+
+            return ObjectInspectorFactory.getStandardStructObjectInspector(fieldNames, fieldOIs);
+        }
+
+        @Override
+        public AggregationBuffer getNewAggregationBuffer() throws HiveException {
+            AggregationBuffer myAggr = new MAPAggregationBuffer();
+            reset(myAggr);
+            return myAggr;
+        }
+
+        @Override
+        public void reset(AggregationBuffer agg) throws HiveException {
+            MAPAggregationBuffer myAggr = (MAPAggregationBuffer) agg;
+            myAggr.reset();
+        }
+
+        @Override
+        public void iterate(AggregationBuffer agg, Object[] parameters) throws HiveException {
+            MAPAggregationBuffer myAggr = (MAPAggregationBuffer) agg;
+
+            List<?> recommendList = recommendListOI.getList(parameters[0]);
+            if (recommendList == null) {
+                recommendList = Collections.emptyList();
+            }
+            List<?> truthList = truthListOI.getList(parameters[1]);
+            if (truthList == null) {
+                return;
+            }
+
+            int recommendSize = recommendList.size();
+            if (parameters.length == 3) {
+                recommendSize = recommendSizeOI.get(parameters[2]);
+            }
+            if (recommendSize < 0 || recommendSize > recommendList.size()) {
+                throw new UDFArgumentException(
+                        "The third argument `int recommendSize` must be in [0, " + recommendList.size() + "]");
+            }
+
+            myAggr.iterate(recommendList, truthList, recommendSize);
+        }
+
+        @Override
+        public Object terminatePartial(AggregationBuffer agg) throws HiveException {
+            MAPAggregationBuffer myAggr = (MAPAggregationBuffer) agg;
+
+            Object[] partialResult = new Object[2];
+            partialResult[0] = new DoubleWritable(myAggr.sum);
+            partialResult[1] = new LongWritable(myAggr.count);
+            return partialResult;
+        }
+
+        @Override
+        public void merge(AggregationBuffer agg, Object partial) throws HiveException {
+            if (partial == null) {
+                return;
+            }
+
+            Object sumObj = internalMergeOI.getStructFieldData(partial, sumField);
+            Object countObj = internalMergeOI.getStructFieldData(partial, countField);
+            double sum = PrimitiveObjectInspectorFactory.writableDoubleObjectInspector.get(sumObj);
+            long count = PrimitiveObjectInspectorFactory.writableLongObjectInspector.get(countObj);
+
+            MAPAggregationBuffer myAggr = (MAPAggregationBuffer) agg;
+            myAggr.merge(sum, count);
+        }
+
+        @Override
+        public DoubleWritable terminate(AggregationBuffer agg) throws HiveException {
+            MAPAggregationBuffer myAggr = (MAPAggregationBuffer) agg;
+            double result = myAggr.get();
+            return new DoubleWritable(result);
+        }
+
+    }
+
+    public static class MAPAggregationBuffer implements AggregationBuffer {
+
+        double sum;
+        long count;
+
+        public MAPAggregationBuffer() {}
+
+        void reset() {
+            this.sum = 0.d;
+            this.count = 0;
+        }
+
+        void merge(double o_sum, long o_count) {
+            sum += o_sum;
+            count += o_count;
+        }
+
+        double get() {
+            if (count == 0) {
+                return 0.d;
+            }
+            return sum / count;
+        }
+
+        void iterate(@Nonnull List<?> recommendList, @Nonnull List<?> truthList, @Nonnull int recommendSize) {
+            sum += BinaryResponsesMeasures.MAP(recommendList, truthList, recommendSize);
+            count++;
+        }
+    }
+
+}

--- a/core/src/main/java/hivemall/evaluation/MRRUDAF.java
+++ b/core/src/main/java/hivemall/evaluation/MRRUDAF.java
@@ -1,0 +1,228 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2015 Makoto YUI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hivemall.evaluation;
+
+import hivemall.utils.hadoop.HiveUtils;
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentTypeException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.udf.generic.AbstractGenericUDAFResolver;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator.AggregationBuffer;
+import org.apache.hadoop.hive.serde2.io.DoubleWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.*;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.WritableIntObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.io.LongWritable;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Description(
+        name = "mrr",
+        value = "_FUNC_(array rankItems, array correctItems [, const int recommendSize = rankItems.size])"
+                + " - Returns MRR")
+public final class MRRUDAF extends AbstractGenericUDAFResolver {
+
+    // prevent instantiation
+    private MRRUDAF() {}
+
+    @Override
+    public GenericUDAFEvaluator getEvaluator(@Nonnull TypeInfo[] typeInfo) throws SemanticException {
+        if (typeInfo.length != 2 && typeInfo.length != 3) {
+            throw new UDFArgumentTypeException(typeInfo.length - 1,
+                "_FUNC_ takes two or three arguments");
+        }
+
+        ListTypeInfo arg1type = HiveUtils.asListTypeInfo(typeInfo[0]);
+        if (!HiveUtils.isPrimitiveTypeInfo(arg1type.getListElementTypeInfo()) &&
+            !HiveUtils.isStructTypeInfo(arg1type.getListElementTypeInfo())) {
+            throw new UDFArgumentTypeException(0,
+                "The first argument `array rankItems` is invalid form: " + typeInfo[0]);
+        }
+        ListTypeInfo arg2type = HiveUtils.asListTypeInfo(typeInfo[1]);
+        if (!HiveUtils.isPrimitiveTypeInfo(arg2type.getListElementTypeInfo())) {
+            throw new UDFArgumentTypeException(1,
+                "The first argument `array rankItems` is invalid form: " + typeInfo[1]);
+        }
+
+        return new Evaluator();
+    }
+
+    public static class Evaluator extends GenericUDAFEvaluator {
+
+        private ListObjectInspector recommendListOI;
+        private ListObjectInspector truthListOI;
+        private WritableIntObjectInspector recommendSizeOI;
+
+        private StructObjectInspector internalMergeOI;
+        private StructField countField;
+        private StructField sumField;
+
+        public Evaluator() {}
+
+        @Override
+        public ObjectInspector init(Mode mode, ObjectInspector[] parameters) throws HiveException {
+            assert (parameters.length == 2 || parameters.length == 3) : parameters.length;
+            super.init(mode, parameters);
+
+            // initialize input
+            if (mode == Mode.PARTIAL1 || mode == Mode.COMPLETE) {// from original data
+                this.recommendListOI = (ListObjectInspector) parameters[0];
+                this.truthListOI = (ListObjectInspector) parameters[1];
+                if (parameters.length == 3) {
+                    this.recommendSizeOI = (WritableIntObjectInspector) parameters[2];
+                }
+            } else {// from partial aggregation
+                StructObjectInspector soi = (StructObjectInspector) parameters[0];
+                this.internalMergeOI = soi;
+                this.countField = soi.getStructFieldRef("count");
+                this.sumField = soi.getStructFieldRef("sum");
+            }
+
+            // initialize output
+            final ObjectInspector outputOI;
+            if (mode == Mode.PARTIAL1 || mode == Mode.PARTIAL2) {// terminatePartial
+                outputOI = internalMergeOI();
+            } else {// terminate
+                outputOI = PrimitiveObjectInspectorFactory.writableDoubleObjectInspector;
+            }
+            return outputOI;
+        }
+
+        private static StructObjectInspector internalMergeOI() {
+            ArrayList<String> fieldNames = new ArrayList<String>();
+            ArrayList<ObjectInspector> fieldOIs = new ArrayList<ObjectInspector>();
+
+            fieldNames.add("sum");
+            fieldOIs.add(PrimitiveObjectInspectorFactory.writableDoubleObjectInspector);
+            fieldNames.add("count");
+            fieldOIs.add(PrimitiveObjectInspectorFactory.writableLongObjectInspector);
+
+            return ObjectInspectorFactory.getStandardStructObjectInspector(fieldNames, fieldOIs);
+        }
+
+        @Override
+        public AggregationBuffer getNewAggregationBuffer() throws HiveException {
+            AggregationBuffer myAggr = new MRRAggregationBuffer();
+            reset(myAggr);
+            return myAggr;
+        }
+
+        @Override
+        public void reset(AggregationBuffer agg) throws HiveException {
+            MRRAggregationBuffer myAggr = (MRRAggregationBuffer) agg;
+            myAggr.reset();
+        }
+
+        @Override
+        public void iterate(AggregationBuffer agg, Object[] parameters) throws HiveException {
+            MRRAggregationBuffer myAggr = (MRRAggregationBuffer) agg;
+
+            List<?> recommendList = recommendListOI.getList(parameters[0]);
+            if (recommendList == null) {
+                recommendList = Collections.emptyList();
+            }
+            List<?> truthList = truthListOI.getList(parameters[1]);
+            if (truthList == null) {
+                return;
+            }
+
+            int recommendSize = recommendList.size();
+            if (parameters.length == 3) {
+                recommendSize = recommendSizeOI.get(parameters[2]);
+            }
+            if (recommendSize < 0 || recommendSize > recommendList.size()) {
+                throw new UDFArgumentException(
+                        "The third argument `int recommendSize` must be in [0, " + recommendList.size() + "]");
+            }
+
+            myAggr.iterate(recommendList, truthList, recommendSize);
+        }
+
+        @Override
+        public Object terminatePartial(AggregationBuffer agg) throws HiveException {
+            MRRAggregationBuffer myAggr = (MRRAggregationBuffer) agg;
+
+            Object[] partialResult = new Object[2];
+            partialResult[0] = new DoubleWritable(myAggr.sum);
+            partialResult[1] = new LongWritable(myAggr.count);
+            return partialResult;
+        }
+
+        @Override
+        public void merge(AggregationBuffer agg, Object partial) throws HiveException {
+            if (partial == null) {
+                return;
+            }
+
+            Object sumObj = internalMergeOI.getStructFieldData(partial, sumField);
+            Object countObj = internalMergeOI.getStructFieldData(partial, countField);
+            double sum = PrimitiveObjectInspectorFactory.writableDoubleObjectInspector.get(sumObj);
+            long count = PrimitiveObjectInspectorFactory.writableLongObjectInspector.get(countObj);
+
+            MRRAggregationBuffer myAggr = (MRRAggregationBuffer) agg;
+            myAggr.merge(sum, count);
+        }
+
+        @Override
+        public DoubleWritable terminate(AggregationBuffer agg) throws HiveException {
+            MRRAggregationBuffer myAggr = (MRRAggregationBuffer) agg;
+            double result = myAggr.get();
+            return new DoubleWritable(result);
+        }
+
+    }
+
+    public static class MRRAggregationBuffer implements AggregationBuffer {
+
+        double sum;
+        long count;
+
+        public MRRAggregationBuffer() {}
+
+        void reset() {
+            this.sum = 0.d;
+            this.count = 0;
+        }
+
+        void merge(double o_sum, long o_count) {
+            sum += o_sum;
+            count += o_count;
+        }
+
+        double get() {
+            if (count == 0) {
+                return 0.d;
+            }
+            return sum / count;
+        }
+
+        void iterate(@Nonnull List<?> recommendList, @Nonnull List<?> truthList, @Nonnull int recommendSize) {
+            sum += BinaryResponsesMeasures.MRR(recommendList, truthList, recommendSize);
+            count++;
+        }
+    }
+
+}

--- a/core/src/main/java/hivemall/evaluation/PrecisionUDAF.java
+++ b/core/src/main/java/hivemall/evaluation/PrecisionUDAF.java
@@ -1,0 +1,228 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2015 Makoto YUI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hivemall.evaluation;
+
+import hivemall.utils.hadoop.HiveUtils;
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentTypeException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.udf.generic.AbstractGenericUDAFResolver;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator.AggregationBuffer;
+import org.apache.hadoop.hive.serde2.io.DoubleWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.*;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.WritableIntObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.io.LongWritable;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Description(
+        name = "precision",
+        value = "_FUNC_(array rankItems, array correctItems [, const int recommendSize = rankItems.size])"
+                + " - Returns Precision")
+public final class PrecisionUDAF extends AbstractGenericUDAFResolver {
+
+    // prevent instantiation
+    private PrecisionUDAF() {}
+
+    @Override
+    public GenericUDAFEvaluator getEvaluator(@Nonnull TypeInfo[] typeInfo) throws SemanticException {
+        if (typeInfo.length != 2 && typeInfo.length != 3) {
+            throw new UDFArgumentTypeException(typeInfo.length - 1,
+                "_FUNC_ takes two or three arguments");
+        }
+
+        ListTypeInfo arg1type = HiveUtils.asListTypeInfo(typeInfo[0]);
+        if (!HiveUtils.isPrimitiveTypeInfo(arg1type.getListElementTypeInfo()) &&
+            !HiveUtils.isStructTypeInfo(arg1type.getListElementTypeInfo())) {
+            throw new UDFArgumentTypeException(0,
+                "The first argument `array rankItems` is invalid form: " + typeInfo[0]);
+        }
+        ListTypeInfo arg2type = HiveUtils.asListTypeInfo(typeInfo[1]);
+        if (!HiveUtils.isPrimitiveTypeInfo(arg2type.getListElementTypeInfo())) {
+            throw new UDFArgumentTypeException(1,
+                "The first argument `array rankItems` is invalid form: " + typeInfo[1]);
+        }
+
+        return new Evaluator();
+    }
+
+    public static class Evaluator extends GenericUDAFEvaluator {
+
+        private ListObjectInspector recommendListOI;
+        private ListObjectInspector truthListOI;
+        private WritableIntObjectInspector recommendSizeOI;
+
+        private StructObjectInspector internalMergeOI;
+        private StructField countField;
+        private StructField sumField;
+
+        public Evaluator() {}
+
+        @Override
+        public ObjectInspector init(Mode mode, ObjectInspector[] parameters) throws HiveException {
+            assert (parameters.length == 2 || parameters.length == 3) : parameters.length;
+            super.init(mode, parameters);
+
+            // initialize input
+            if (mode == Mode.PARTIAL1 || mode == Mode.COMPLETE) {// from original data
+                this.recommendListOI = (ListObjectInspector) parameters[0];
+                this.truthListOI = (ListObjectInspector) parameters[1];
+                if (parameters.length == 3) {
+                    this.recommendSizeOI = (WritableIntObjectInspector) parameters[2];
+                }
+            } else {// from partial aggregation
+                StructObjectInspector soi = (StructObjectInspector) parameters[0];
+                this.internalMergeOI = soi;
+                this.countField = soi.getStructFieldRef("count");
+                this.sumField = soi.getStructFieldRef("sum");
+            }
+
+            // initialize output
+            final ObjectInspector outputOI;
+            if (mode == Mode.PARTIAL1 || mode == Mode.PARTIAL2) {// terminatePartial
+                outputOI = internalMergeOI();
+            } else {// terminate
+                outputOI = PrimitiveObjectInspectorFactory.writableDoubleObjectInspector;
+            }
+            return outputOI;
+        }
+
+        private static StructObjectInspector internalMergeOI() {
+            ArrayList<String> fieldNames = new ArrayList<String>();
+            ArrayList<ObjectInspector> fieldOIs = new ArrayList<ObjectInspector>();
+
+            fieldNames.add("sum");
+            fieldOIs.add(PrimitiveObjectInspectorFactory.writableDoubleObjectInspector);
+            fieldNames.add("count");
+            fieldOIs.add(PrimitiveObjectInspectorFactory.writableLongObjectInspector);
+
+            return ObjectInspectorFactory.getStandardStructObjectInspector(fieldNames, fieldOIs);
+        }
+
+        @Override
+        public AggregationBuffer getNewAggregationBuffer() throws HiveException {
+            AggregationBuffer myAggr = new PrecisionAggregationBuffer();
+            reset(myAggr);
+            return myAggr;
+        }
+
+        @Override
+        public void reset(AggregationBuffer agg) throws HiveException {
+            PrecisionAggregationBuffer myAggr = (PrecisionAggregationBuffer) agg;
+            myAggr.reset();
+        }
+
+        @Override
+        public void iterate(AggregationBuffer agg, Object[] parameters) throws HiveException {
+            PrecisionAggregationBuffer myAggr = (PrecisionAggregationBuffer) agg;
+
+            List<?> recommendList = recommendListOI.getList(parameters[0]);
+            if (recommendList == null) {
+                recommendList = Collections.emptyList();
+            }
+            List<?> truthList = truthListOI.getList(parameters[1]);
+            if (truthList == null) {
+                return;
+            }
+
+            int recommendSize = recommendList.size();
+            if (parameters.length == 3) {
+                recommendSize = recommendSizeOI.get(parameters[2]);
+            }
+            if (recommendSize < 0 || recommendSize > recommendList.size()) {
+                throw new UDFArgumentException(
+                        "The third argument `int recommendSize` must be in [0, " + recommendList.size() + "]");
+            }
+
+            myAggr.iterate(recommendList, truthList, recommendSize);
+        }
+
+        @Override
+        public Object terminatePartial(AggregationBuffer agg) throws HiveException {
+            PrecisionAggregationBuffer myAggr = (PrecisionAggregationBuffer) agg;
+
+            Object[] partialResult = new Object[2];
+            partialResult[0] = new DoubleWritable(myAggr.sum);
+            partialResult[1] = new LongWritable(myAggr.count);
+            return partialResult;
+        }
+
+        @Override
+        public void merge(AggregationBuffer agg, Object partial) throws HiveException {
+            if (partial == null) {
+                return;
+            }
+
+            Object sumObj = internalMergeOI.getStructFieldData(partial, sumField);
+            Object countObj = internalMergeOI.getStructFieldData(partial, countField);
+            double sum = PrimitiveObjectInspectorFactory.writableDoubleObjectInspector.get(sumObj);
+            long count = PrimitiveObjectInspectorFactory.writableLongObjectInspector.get(countObj);
+
+            PrecisionAggregationBuffer myAggr = (PrecisionAggregationBuffer) agg;
+            myAggr.merge(sum, count);
+        }
+
+        @Override
+        public DoubleWritable terminate(AggregationBuffer agg) throws HiveException {
+            PrecisionAggregationBuffer myAggr = (PrecisionAggregationBuffer) agg;
+            double result = myAggr.get();
+            return new DoubleWritable(result);
+        }
+
+    }
+
+    public static class PrecisionAggregationBuffer implements AggregationBuffer {
+
+        double sum;
+        long count;
+
+        public PrecisionAggregationBuffer() {}
+
+        void reset() {
+            this.sum = 0.d;
+            this.count = 0;
+        }
+
+        void merge(double o_sum, long o_count) {
+            sum += o_sum;
+            count += o_count;
+        }
+
+        double get() {
+            if (count == 0) {
+                return 0.d;
+            }
+            return sum / count;
+        }
+
+        void iterate(@Nonnull List<?> recommendList, @Nonnull List<?> truthList, @Nonnull int recommendSize) {
+            sum += BinaryResponsesMeasures.Precision(recommendList, truthList, recommendSize);
+            count++;
+        }
+    }
+
+}

--- a/core/src/main/java/hivemall/evaluation/RecallUDAF.java
+++ b/core/src/main/java/hivemall/evaluation/RecallUDAF.java
@@ -1,0 +1,228 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2015 Makoto YUI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hivemall.evaluation;
+
+import hivemall.utils.hadoop.HiveUtils;
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentTypeException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.udf.generic.AbstractGenericUDAFResolver;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator.AggregationBuffer;
+import org.apache.hadoop.hive.serde2.io.DoubleWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.*;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.WritableIntObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.io.LongWritable;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Description(
+        name = "recall",
+        value = "_FUNC_(array rankItems, array correctItems [, const int recommendSize = rankItems.size])"
+                + " - Returns Recall")
+public final class RecallUDAF extends AbstractGenericUDAFResolver {
+
+    // prevent instantiation
+    private RecallUDAF() {}
+
+    @Override
+    public GenericUDAFEvaluator getEvaluator(@Nonnull TypeInfo[] typeInfo) throws SemanticException {
+        if (typeInfo.length != 2 && typeInfo.length != 3) {
+            throw new UDFArgumentTypeException(typeInfo.length - 1,
+                "_FUNC_ takes two or three arguments");
+        }
+
+        ListTypeInfo arg1type = HiveUtils.asListTypeInfo(typeInfo[0]);
+        if (!HiveUtils.isPrimitiveTypeInfo(arg1type.getListElementTypeInfo()) &&
+            !HiveUtils.isStructTypeInfo(arg1type.getListElementTypeInfo())) {
+            throw new UDFArgumentTypeException(0,
+                "The first argument `array rankItems` is invalid form: " + typeInfo[0]);
+        }
+        ListTypeInfo arg2type = HiveUtils.asListTypeInfo(typeInfo[1]);
+        if (!HiveUtils.isPrimitiveTypeInfo(arg2type.getListElementTypeInfo())) {
+            throw new UDFArgumentTypeException(1,
+                "The first argument `array rankItems` is invalid form: " + typeInfo[1]);
+        }
+
+        return new Evaluator();
+    }
+
+    public static class Evaluator extends GenericUDAFEvaluator {
+
+        private ListObjectInspector recommendListOI;
+        private ListObjectInspector truthListOI;
+        private WritableIntObjectInspector recommendSizeOI;
+
+        private StructObjectInspector internalMergeOI;
+        private StructField countField;
+        private StructField sumField;
+
+        public Evaluator() {}
+
+        @Override
+        public ObjectInspector init(Mode mode, ObjectInspector[] parameters) throws HiveException {
+            assert (parameters.length == 2 || parameters.length == 3) : parameters.length;
+            super.init(mode, parameters);
+
+            // initialize input
+            if (mode == Mode.PARTIAL1 || mode == Mode.COMPLETE) {// from original data
+                this.recommendListOI = (ListObjectInspector) parameters[0];
+                this.truthListOI = (ListObjectInspector) parameters[1];
+                if (parameters.length == 3) {
+                    this.recommendSizeOI = (WritableIntObjectInspector) parameters[2];
+                }
+            } else {// from partial aggregation
+                StructObjectInspector soi = (StructObjectInspector) parameters[0];
+                this.internalMergeOI = soi;
+                this.countField = soi.getStructFieldRef("count");
+                this.sumField = soi.getStructFieldRef("sum");
+            }
+
+            // initialize output
+            final ObjectInspector outputOI;
+            if (mode == Mode.PARTIAL1 || mode == Mode.PARTIAL2) {// terminatePartial
+                outputOI = internalMergeOI();
+            } else {// terminate
+                outputOI = PrimitiveObjectInspectorFactory.writableDoubleObjectInspector;
+            }
+            return outputOI;
+        }
+
+        private static StructObjectInspector internalMergeOI() {
+            ArrayList<String> fieldNames = new ArrayList<String>();
+            ArrayList<ObjectInspector> fieldOIs = new ArrayList<ObjectInspector>();
+
+            fieldNames.add("sum");
+            fieldOIs.add(PrimitiveObjectInspectorFactory.writableDoubleObjectInspector);
+            fieldNames.add("count");
+            fieldOIs.add(PrimitiveObjectInspectorFactory.writableLongObjectInspector);
+
+            return ObjectInspectorFactory.getStandardStructObjectInspector(fieldNames, fieldOIs);
+        }
+
+        @Override
+        public AggregationBuffer getNewAggregationBuffer() throws HiveException {
+            AggregationBuffer myAggr = new RecallAggregationBuffer();
+            reset(myAggr);
+            return myAggr;
+        }
+
+        @Override
+        public void reset(AggregationBuffer agg) throws HiveException {
+            RecallAggregationBuffer myAggr = (RecallAggregationBuffer) agg;
+            myAggr.reset();
+        }
+
+        @Override
+        public void iterate(AggregationBuffer agg, Object[] parameters) throws HiveException {
+            RecallAggregationBuffer myAggr = (RecallAggregationBuffer) agg;
+
+            List<?> recommendList = recommendListOI.getList(parameters[0]);
+            if (recommendList == null) {
+                recommendList = Collections.emptyList();
+            }
+            List<?> truthList = truthListOI.getList(parameters[1]);
+            if (truthList == null) {
+                return;
+            }
+
+            int recommendSize = recommendList.size();
+            if (parameters.length == 3) {
+                recommendSize = recommendSizeOI.get(parameters[2]);
+            }
+            if (recommendSize < 0 || recommendSize > recommendList.size()) {
+                throw new UDFArgumentException(
+                        "The third argument `int recommendSize` must be in [0, " + recommendList.size() + "]");
+            }
+
+            myAggr.iterate(recommendList, truthList, recommendSize);
+        }
+
+        @Override
+        public Object terminatePartial(AggregationBuffer agg) throws HiveException {
+            RecallAggregationBuffer myAggr = (RecallAggregationBuffer) agg;
+
+            Object[] partialResult = new Object[2];
+            partialResult[0] = new DoubleWritable(myAggr.sum);
+            partialResult[1] = new LongWritable(myAggr.count);
+            return partialResult;
+        }
+
+        @Override
+        public void merge(AggregationBuffer agg, Object partial) throws HiveException {
+            if (partial == null) {
+                return;
+            }
+
+            Object sumObj = internalMergeOI.getStructFieldData(partial, sumField);
+            Object countObj = internalMergeOI.getStructFieldData(partial, countField);
+            double sum = PrimitiveObjectInspectorFactory.writableDoubleObjectInspector.get(sumObj);
+            long count = PrimitiveObjectInspectorFactory.writableLongObjectInspector.get(countObj);
+
+            RecallAggregationBuffer myAggr = (RecallAggregationBuffer) agg;
+            myAggr.merge(sum, count);
+        }
+
+        @Override
+        public DoubleWritable terminate(AggregationBuffer agg) throws HiveException {
+            RecallAggregationBuffer myAggr = (RecallAggregationBuffer) agg;
+            double result = myAggr.get();
+            return new DoubleWritable(result);
+        }
+
+    }
+
+    public static class RecallAggregationBuffer implements AggregationBuffer {
+
+        double sum;
+        long count;
+
+        public RecallAggregationBuffer() {}
+
+        void reset() {
+            this.sum = 0.d;
+            this.count = 0;
+        }
+
+        void merge(double o_sum, long o_count) {
+            sum += o_sum;
+            count += o_count;
+        }
+
+        double get() {
+            if (count == 0) {
+                return 0.d;
+            }
+            return sum / count;
+        }
+
+        void iterate(@Nonnull List<?> recommendList, @Nonnull List<?> truthList, @Nonnull int recommendSize) {
+            sum += BinaryResponsesMeasures.Recall(recommendList, truthList, recommendSize);
+            count++;
+        }
+    }
+
+}

--- a/core/src/main/java/hivemall/utils/hadoop/HiveUtils.java
+++ b/core/src/main/java/hivemall/utils/hadoop/HiveUtils.java
@@ -165,6 +165,10 @@ public final class HiveUtils {
         return oi.getCategory() == Category.PRIMITIVE;
     }
 
+    public static boolean isStructOI(@Nonnull final ObjectInspector oi) {
+        return oi.getCategory() == Category.STRUCT;
+    }
+
     public static boolean isStringOI(@Nonnull final ObjectInspector oi) {
         String typeName = oi.getTypeName();
         return STRING_TYPE_NAME.equals(typeName);
@@ -229,6 +233,10 @@ public final class HiveUtils {
 
     public static boolean isPrimitiveTypeInfo(@Nonnull TypeInfo typeInfo) {
         return typeInfo.getCategory() == ObjectInspector.Category.PRIMITIVE;
+    }
+
+    public static boolean isStructTypeInfo(@Nonnull TypeInfo typeInfo) {
+        return typeInfo.getCategory() == ObjectInspector.Category.STRUCT;
     }
 
     public static boolean isNumberTypeInfo(@Nonnull TypeInfo typeInfo) {

--- a/core/src/test/java/hivemall/evaluation/BinaryResponsesMeasuresTest.java
+++ b/core/src/test/java/hivemall/evaluation/BinaryResponsesMeasuresTest.java
@@ -27,10 +27,10 @@ public class BinaryResponsesMeasuresTest {
 
     @Test
     public void testNDCG() {
-        List<Integer> rankedList = Arrays.asList(3, 0, 2, 1, 1);
-        List<Integer> groundTruth = Arrays.asList(3, 2, 1, 1, 4);
+        List<Integer> rankedList = Arrays.asList(1, 3, 2, 6);
+        List<Integer> groundTruth = Arrays.asList(1, 2, 4);
         double actual = BinaryResponsesMeasures.nDCG(rankedList, groundTruth);
-        Assert.assertEquals(0.7860137352654725d, actual, 0.0001d);
+        Assert.assertEquals(0.7039180890341348d, actual, 0.0001d);
     }
 
 }

--- a/core/src/test/java/hivemall/evaluation/BinaryResponsesMeasuresTest.java
+++ b/core/src/test/java/hivemall/evaluation/BinaryResponsesMeasuresTest.java
@@ -17,6 +17,7 @@
  */
 package hivemall.evaluation;
 
+import java.util.Collections;
 import java.util.Arrays;
 import java.util.List;
 
@@ -35,6 +36,71 @@ public class BinaryResponsesMeasuresTest {
 
         actual = BinaryResponsesMeasures.nDCG(rankedList, groundTruth, 2);
         Assert.assertEquals(0.6131471927654585d, actual, 0.0001d);
+    }
+
+    @Test
+    public void testRecall() {
+        List<Integer> rankedList = Arrays.asList(1, 3, 2, 6);
+        List<Integer> groundTruth = Arrays.asList(1, 2, 4);
+
+        double actual = BinaryResponsesMeasures.Recall(rankedList, groundTruth, rankedList.size());
+        Assert.assertEquals(0.6666666666666666d, actual, 0.0001d);
+
+        actual = BinaryResponsesMeasures.Recall(rankedList, groundTruth, 2);
+        Assert.assertEquals(0.3333333333333333d, actual, 0.0001d);
+    }
+
+    @Test
+    public void testPrecision() {
+        List<Integer> rankedList = Arrays.asList(1, 3, 2, 6);
+        List<Integer> groundTruth = Arrays.asList(1, 2, 4);
+
+        double actual = BinaryResponsesMeasures.Precision(rankedList, groundTruth, rankedList.size());
+        Assert.assertEquals(0.5d, actual, 0.0001d);
+
+        actual = BinaryResponsesMeasures.Precision(rankedList, groundTruth, 2);
+        Assert.assertEquals(0.5d, actual, 0.0001d);
+    }
+
+    @Test
+    public void testMRR() {
+        List<Integer> rankedList = Arrays.asList(1, 3, 2, 6);
+        List<Integer> groundTruth = Arrays.asList(1, 2, 4);
+
+        double actual = BinaryResponsesMeasures.MRR(rankedList, groundTruth, rankedList.size());
+        Assert.assertEquals(1.0d, actual, 0.0001d);
+
+        Collections.reverse(rankedList);
+
+        actual = BinaryResponsesMeasures.MRR(rankedList, groundTruth, rankedList.size());
+        Assert.assertEquals(0.5d, actual, 0.0001d);
+
+        actual = BinaryResponsesMeasures.MRR(rankedList, groundTruth, 1);
+        Assert.assertEquals(0.0d, actual, 0.0001d);
+    }
+
+    @Test
+    public void testMAP() {
+        List<Integer> rankedList = Arrays.asList(1, 3, 2, 6);
+        List<Integer> groundTruth = Arrays.asList(1, 2, 4);
+
+        double actual = BinaryResponsesMeasures.MAP(rankedList, groundTruth, rankedList.size());
+        Assert.assertEquals(0.5555555555555555d, actual, 0.0001d);
+
+        actual = BinaryResponsesMeasures.MAP(rankedList, groundTruth, 2);
+        Assert.assertEquals(0.3333333333333333d, actual, 0.0001d);
+    }
+
+    @Test
+    public void testAUC() {
+        List<Integer> rankedList = Arrays.asList(1, 3, 2, 6);
+        List<Integer> groundTruth = Arrays.asList(1, 2, 4);
+
+        double actual = BinaryResponsesMeasures.AUC(rankedList, groundTruth, rankedList.size());
+        Assert.assertEquals(0.75d, actual, 0.0001d);
+
+        actual = BinaryResponsesMeasures.AUC(rankedList, groundTruth, 2);
+        Assert.assertEquals(1.0d, actual, 0.0001d);
     }
 
 }

--- a/core/src/test/java/hivemall/evaluation/BinaryResponsesMeasuresTest.java
+++ b/core/src/test/java/hivemall/evaluation/BinaryResponsesMeasuresTest.java
@@ -29,8 +29,12 @@ public class BinaryResponsesMeasuresTest {
     public void testNDCG() {
         List<Integer> rankedList = Arrays.asList(1, 3, 2, 6);
         List<Integer> groundTruth = Arrays.asList(1, 2, 4);
-        double actual = BinaryResponsesMeasures.nDCG(rankedList, groundTruth);
+
+        double actual = BinaryResponsesMeasures.nDCG(rankedList, groundTruth, rankedList.size());
         Assert.assertEquals(0.7039180890341348d, actual, 0.0001d);
+
+        actual = BinaryResponsesMeasures.nDCG(rankedList, groundTruth, 2);
+        Assert.assertEquals(0.6131471927654585d, actual, 0.0001d);
     }
 
 }

--- a/core/src/test/java/hivemall/evaluation/GradedResponsesMeasuresTest.java
+++ b/core/src/test/java/hivemall/evaluation/GradedResponsesMeasuresTest.java
@@ -1,0 +1,40 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2015 Makoto YUI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hivemall.evaluation;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class GradedResponsesMeasuresTest {
+
+    @Test
+    public void testNDCG() {
+        List<Double> recommendTopRelScoreList = Arrays.asList(5.0, 2.0, 4.0, 1.0, 3.0);
+        List<Double> truthTopRelScoreList = Arrays.asList(5.0, 4.0, 3.0);
+
+        double actual = GradedResponsesMeasures.nDCG(recommendTopRelScoreList, truthTopRelScoreList, 3);
+        Assert.assertEquals(0.918770780535d, actual, 0.0001d);
+
+        actual = GradedResponsesMeasures.nDCG(recommendTopRelScoreList, truthTopRelScoreList, 2);
+        Assert.assertEquals(0.812891283859d, actual, 0.0001d);
+    }
+
+}


### PR DESCRIPTION
(extended from #321 )

### Summary of this PR

- Update the original nDCG implementation w/ supporting graded responses
- Implement new ranking measures (for binary responses)
  - Precision
  - Recall
  - MRR (Mean Reciprocal Rank)
  - MAP (Mean Average Precision)
  - AUC (the area under the ROC curve)

### Interfaces

All of the above measures have the same interfaces as:

- `ndcg(array rankItems, array correctItems [, const int recommendSize = rankItems.size])`
  - **Binary** (other measures are also same)
    - `rankItems` &mdash; Ranked list of recommended item IDs
    - `correctItems` &mdash; List of truth item IDs
  - **Graded** (only NDCG)
    - `rankItems` &mdash; Ordered list of structs <relScore, item> for recommended items
    - `correctItems` &mdash; Ordered list of relScores for truth items
- `precision(rankItems, correctItems, recommendSize)`
- `recall(rankItems, correctItems, recommendSize)`
- `mrr(rankItems, correctItems, recommendSize)`
- `average_precision(rankItems, correctItems, recommendSize)`
  - `map()` already exists on Hive
- `auc(rankItems, correctItems, recommendSize)`

### Running test on Hive

#### Case: Binary

**dummy_truth**

|userid|itemid|
|:---:|:---:|
|1      | 1|
|1      | 2|
|1       |4|
|2     |  1|
|2    |   2|
|2   |    4|
|3  |     1|
|3 |      2|
|3|       4|

**dummy_rec**

|userid|itemid|score|
|:---:|:---:|:---:|
|1    |  1   |   10.0|
|1    |  3   |   8.0 |
|1    |  2   |   6.0 |
|1    |  6   |   2.0 |
|2    |  1   |   10.0|
|2    |  3   |   8.0 |
|2    |  2   |   6.0 |
|2    |  6   |   2.0 |
|3    |  1   |   10.0|
|3    |  3   |   8.0 |
|3    |  2   |   6.0 |
|3    |  6   |   2.0 |

For each user, I've set the exactly same item IDs as [the unit test](https://github.com/takuti/hivemall/blob/4c3f999390d99c1c7c5daf062b3ff6f4a78d47d6/core/src/test/java/hivemall/evaluation/BinaryResponsesMeasuresTest.java).

```sql
with truth as (
  select userid, collect_set(itemid) as truth
  from dummy_truth
  group by userid
),
rec as (
  select
    userid,
    map_values(to_ordered_map(score, itemid, true)) as rec,
    cast(count(itemid) as int) as max_k
  from dummy_rec
  group by userid
)
select
  ndcg(t1.rec, t2.truth, t1.max_k) as ndcgk, ndcg(t1.rec, t2.truth, 2) as ndcg2,
  precision(t1.rec, t2.truth, t1.max_k) as precisionk, precision(t1.rec, t2.truth, 2) as precision2,
  recall(t1.rec, t2.truth, t1.max_k) as recallk, recall(t1.rec, t2.truth, 2) as recall2,
  mrr(t1.rec, t2.truth, t1.max_k) as mrrk, mrr(t1.rec, t2.truth, 2) as mrr2,
  average_precision(t1.rec, t2.truth, t1.max_k) as average_precisionk, average_precision(t1.rec, t2.truth, 2) as average_precision2,
  auc(t1.rec, t2.truth, t1.max_k) as auck, auc(t1.rec, t2.truth, 2) as auc2
from rec t1
join truth t2 on (t1.userid = t2.userid)
;
```

||@k (all of rankedList) | @2 |
|:---:|:---|:---|
|NDCG  |0.7039180890341349    |  0.6131471927654585  |
|Precision | 0.5   |  0.5 |
|Recall  | 0.6666666666666666    |  0.3333333333333333   |
|MRR   |  1.0   |  1.0 |
|MAP   | 0.5555555555555555    |  0.3333333333333333 |
|AUC    |      0.75 |   1.0|

All them equal to the expected values of the unit test.

#### Case: Graded

**dummy_recrel**

| userid  |  itemid  |   score  |    relscore |
|:---:|:---:|:---:|:---:|
|1   |   1   |   10.0  | 5.0
|1   |   3   |   8.0   | 2.0
|1   |   2   |   6.0   | 4.0
|1   |   6   |   2.0   | 1.0
|1   |   4   |   1.0   | 3.0
|2   |   1   |   10.0  | 5.0
|2   |   3   |   8.0   | 2.0
|2   |   2   |   6.0   | 4.0
|2   |   6   |   2.0   | 1.0
|2   |   4   |   1.0   | 3.0
|3   |   1   |   10.0  | 5.0
|3   |   3   |   8.0   | 2.0
|3   |   2   |   6.0   | 4.0
|3   |   6   |   2.0   | 1.0
|3   |   4   |   1.0   | 3.0

Similarly to the binary case, each user has the same item-relScore pairs as [the unit test case](https://github.com/takuti/hivemall/blob/4c3f999390d99c1c7c5daf062b3ff6f4a78d47d6/core/src/test/java/hivemall/evaluation/GradedResponsesMeasuresTest.java).

```sql
with truth as (
  select userid, map_keys(to_ordered_map(relscore, itemid, true)) as truth
  from dummy_recrel
  group by userid
),
rec as (
  select
    userid,
    map_values (
      to_ordered_map(score, struct(relscore, itemid), true)
    ) as rec,
    cast(count(itemid) as int) as max_k
  from dummy_recrel
  group by userid
)
select ndcg(t1.rec, t2.truth, 3)
from rec t1
join truth t2 on (t1.userid = t2.userid)
;
```

- `ndcg(t1.rec, t2.truth, 3)` => **0.9187707805346093**
- `ndcg(t1.rec, t2.truth, 2)` => **0.8128912838590544**

Also equal to the unit test.

### References

- B. McFee and G. R. Lanckriet. "[Metric Learning to Rank](https://bmcfee.github.io/papers/mlr.pdf)" ICML 2010.
- [MyMediaLite implementation](https://github.com/zenogantner/MyMediaLite/tree/9063a2e468160c3503ea96c0c3fdbc35b529633d/src/MyMediaLite/Eval/Measures)
- [LibRec implementation](https://github.com/guoguibing/librec/blob/master/librec/src/main/java/librec/util/Measures.java)

Note: `resources/ddl/define-*.hive` will be updated after your review.