### PR TITLE
Remove an unnecessary entry in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ branches:
   only:
     - master
     - develop
-    - dev/spark
 
 notifications:
   email: false


### PR DESCRIPTION
`dev/spark` has gone.