### PR TITLE
Turn on tests for spark-v1.6 and spark-v2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,9 @@ branches:
 notifications:
   email: false
 
+script:
+  - mvn test -Pspark-1.6
+  - mvn test -Pspark-2.0
+
 after_success:
   - mvn clean cobertura:cobertura coveralls:report


### PR DESCRIPTION
This update is to turn on tests for `/spark` submodules.