### PR TITLE
Implement `arburg()` and some minor fixes on MatrixUtils

### DIFF
--- a/core/src/main/java/hivemall/anomaly/SDAR1D.java
+++ b/core/src/main/java/hivemall/anomaly/SDAR1D.java
@@ -96,7 +96,7 @@ public final class SDAR1D {
         // \hat{x} = \hat{µ} + ∑_{i=1}^k A_i (x_{t-i} - \hat{µ})
         double x_hat = _mu;
         for (int i = 1; i <= k; i++) {
-            x_hat += (-A[i]) * (x[i] - _mu); // -A[i] when solved by aryule()
+            x_hat += A[i] * (x[i] - _mu);
         }
 
         // update model covariance

--- a/core/src/main/java/hivemall/utils/math/MatrixUtils.java
+++ b/core/src/main/java/hivemall/utils/math/MatrixUtils.java
@@ -70,6 +70,10 @@ public final class MatrixUtils {
             E[k + 1] = Ek * (1.0d - lambda * lambda);
         }
 
+        for (int i = 0; i < order + 1; i++) {
+            A[i] = -A[i];
+        }
+
         return E;
     }
 
@@ -106,6 +110,10 @@ public final class MatrixUtils {
             }
 
             E[k + 1] = E[k] * (1.0d - lambda * lambda);
+        }
+
+        for (int i = 0; i < order + 1; i++) {
+            A[i] = -A[i];
         }
 
         return E;
@@ -197,6 +205,10 @@ public final class MatrixUtils {
             final double tmp = A[i];
             A[i] = A[order + 1 - i];
             A[order + 1 - i] = tmp;
+        }
+
+        for (int i = 0; i < order + 1; i++) {
+            A[i] = -A[i];
         }
 
         return E;

--- a/core/src/test/java/hivemall/utils/math/MatrixUtilsTest.java
+++ b/core/src/test/java/hivemall/utils/math/MatrixUtilsTest.java
@@ -85,8 +85,8 @@ public class MatrixUtilsTest {
                 new Array2DRowRealMatrix(new double[] {1}),
                 new Array2DRowRealMatrix(new double[] {2})}, A[1]);
         Assert.assertArrayEquals(new RealMatrix[] {new Array2DRowRealMatrix(new double[] {3}),
-                new Array2DRowRealMatrix(new double[] {1}),
-                new Array2DRowRealMatrix(new double[] {2})}, A[2]);
+                new Array2DRowRealMatrix(new double[] {2}),
+                new Array2DRowRealMatrix(new double[] {1})}, A[2]);
     }
 
 

--- a/core/src/test/java/hivemall/utils/math/MatrixUtilsTest.java
+++ b/core/src/test/java/hivemall/utils/math/MatrixUtilsTest.java
@@ -47,6 +47,29 @@ public class MatrixUtilsTest {
     }
 
     @Test
+    public void testArburgk2() {
+        // Expected outputs are obtained from Octave's arburg() function
+        // k must be less than (X.length - 2) on Octave, but A can be computed w/o the assumption
+        int k = 2;
+        double[] X = new double[] {1, 2, 3, 4, 5};
+        double[] A = new double[k + 1];
+        MatrixUtils.arburg(X, A, k);
+        Assert.assertEquals(1.86391d, A[1], 0.00001d);
+        Assert.assertEquals(-0.95710d, A[2], 0.00001d);
+    }
+
+    @Test
+    public void testArburgk5() {
+        final int k = 5;
+        double[] X = new double[] {143.85, 141.95, 141.45, 142.30, 140.60, 140.00, 138.40, 137.10,
+                138.90, 139.85};
+        double[] A = new double[k + 1];
+        MatrixUtils.arburg(X, A, k);
+        double[] expected = new double[] {1.0, 1.31033, -0.58569, 0.56058, -0.63859, 0.35334};
+        Assert.assertArrayEquals(expected, A, 0.00001d);
+    }
+
+    @Test
     public void toeplitz() {
         RealMatrix[] c = new RealMatrix[] {new Array2DRowRealMatrix(new double[] {1}),
                 new Array2DRowRealMatrix(new double[] {2}),

--- a/core/src/test/java/hivemall/utils/math/MatrixUtilsTest.java
+++ b/core/src/test/java/hivemall/utils/math/MatrixUtilsTest.java
@@ -30,8 +30,8 @@ public class MatrixUtilsTest {
         double[] R = new double[] {1, 2, 3};
         double[] A = new double[k + 1];
         MatrixUtils.aryule(R, A, k);
-        Assert.assertEquals(-1.3333333333333335d, A[1], 0.001d);
-        Assert.assertEquals(-0.3333333333333333d, A[2], 0.001d);
+        Assert.assertEquals(1.3333333333333335d, A[1], 0.001d);
+        Assert.assertEquals(0.3333333333333333d, A[2], 0.001d);
     }
 
     @Test
@@ -41,8 +41,8 @@ public class MatrixUtilsTest {
                 138.90, 139.85};
         double[] A = new double[k + 1];
         MatrixUtils.aryule(R, A, k);
-        double[] expected = new double[] {1.0, -2.90380682, -0.31235631, -1.26463104, 3.30187384,
-                1.61653593, 2.10367317, -1.37563117, -2.18139823, -0.02314717};
+        double[] expected = new double[] {-1.0, 2.90380682, 0.31235631, 1.26463104, -3.30187384,
+                -1.61653593, -2.10367317, 1.37563117, 2.18139823, 0.02314717};
         Assert.assertArrayEquals(expected, A, 0.01d);
     }
 
@@ -54,8 +54,8 @@ public class MatrixUtilsTest {
         double[] X = new double[] {1, 2, 3, 4, 5};
         double[] A = new double[k + 1];
         MatrixUtils.arburg(X, A, k);
-        Assert.assertEquals(1.86391d, A[1], 0.00001d);
-        Assert.assertEquals(-0.95710d, A[2], 0.00001d);
+        Assert.assertEquals(-1.86391d, A[1], 0.00001d);
+        Assert.assertEquals(0.95710d, A[2], 0.00001d);
     }
 
     @Test
@@ -65,7 +65,7 @@ public class MatrixUtilsTest {
                 138.90, 139.85};
         double[] A = new double[k + 1];
         MatrixUtils.arburg(X, A, k);
-        double[] expected = new double[] {1.0, 1.31033, -0.58569, 0.56058, -0.63859, 0.35334};
+        double[] expected = new double[] {-1.0, -1.31033, 0.58569, -0.56058, 0.63859, -0.35334};
         Assert.assertArrayEquals(expected, A, 0.00001d);
     }
 


### PR DESCRIPTION
### Summary

- Implement `arburg()`, an alternative way to estimate the AR(k) model parameters.
  - [MATLAB's reference implementation](https://searchcode.com/codesearch/view/9503568/)
  - [Python version w/o vectorization](https://github.com/takuti/datadog-anomaly-detector/blob/e414f41c669577ed7704368ea130f9e6e7016b21/core/changefinder/utils.py#L70-L119)
- Return `-A` instead of `A` in `aryule()`, `aryule2()` and `arburg()`.
- Fix MarixUtilsTest in order to successfully pass unit testing for the module.