### PR TITLE
Support Hellinger-distance-based scoring both on SDAR 1D and 2D

### DIFF
--- a/core/src/main/java/hivemall/anomaly/ChangeFinder1D.java
+++ b/core/src/main/java/hivemall/anomaly/ChangeFinder1D.java
@@ -62,7 +62,12 @@ final class ChangeFinder1D implements ChangeFinder {
         xRing.add(x).toArray(xSeries, false /* LIFO */);
         int k1 = xRing.size() - 1;
         double x_hat = sdar1.update(xSeries, k1);
+
+        // <LogLoss>
         double scoreX = (k1 == 0.d) ? 0.d : sdar1.logLoss(x, x_hat);
+        // <Hellinger distance>
+        // double scoreX = (k1 == 0.d) ? 0.d : sdar1.hellingerDistance();
+
         // smoothing
         double y = ChangeFinderUDF.smoothing(outlierScores.add(scoreX));
 
@@ -70,8 +75,13 @@ final class ChangeFinder1D implements ChangeFinder {
         yRing.add(y).toArray(ySeries, false /* LIFO */);
         int k2 = yRing.size() - 1;
         double y_hat = sdar2.update(ySeries, k2);
+
+        // <LogLoss>
         double lossY = (k2 == 0.d) ? 0.d : sdar2.logLoss(y, y_hat);
         double scoreY = ChangeFinderUDF.smoothing(changepointScores.add(lossY));
+        // <Hellinger distance>
+        // double distanceY = (k2 == 0.d) ? 0.d : sdar2.hellingerDistance();
+        // double scoreY = ChangeFinderUDF.smoothing(changepointScores.add(distanceY));
 
         outScores[0] = scoreX;
         outScores[1] = scoreY;

--- a/core/src/main/java/hivemall/anomaly/ChangeFinder2D.java
+++ b/core/src/main/java/hivemall/anomaly/ChangeFinder2D.java
@@ -78,7 +78,12 @@ final class ChangeFinder2D implements ChangeFinder {
         xRing.add(x).toArray(xSeries, false /* LIFO */);
         int k1 = xRing.size() - 1;
         RealVector x_hat = sdar1.update(xSeries, k1);
+
+        // <LogLoss>
         double scoreX = (k1 == 0.d) ? 0.d : sdar1.logLoss(x, x_hat);
+        // <Hellinger distance>
+        // double scoreX = (k1 == 0.d) ? 0.d : sdar1.hellingerDistance();
+
         // smoothing
         double y = ChangeFinderUDF.smoothing(outlierScores.add(scoreX));
 
@@ -86,8 +91,13 @@ final class ChangeFinder2D implements ChangeFinder {
         yRing.add(y).toArray(ySeries, false /* LIFO */);
         int k2 = yRing.size() - 1;
         double y_hat = sdar2.update(ySeries, k2);
+
+        // <LogLoss>
         double lossY = (k2 == 0.d) ? 0.d : sdar2.logLoss(y, y_hat);
         double scoreY = ChangeFinderUDF.smoothing(changepointScores.add(lossY));
+        // <Hellinger distance>
+        // double distanceY = (k2 == 0.d) ? 0.d : sdar2.hellingerDistance();
+        // double scoreY = ChangeFinderUDF.smoothing(changepointScores.add(distanceY));
 
         outScores[0] = scoreX;
         outScores[1] = scoreY;

--- a/core/src/main/java/hivemall/anomaly/SDAR1D.java
+++ b/core/src/main/java/hivemall/anomaly/SDAR1D.java
@@ -42,6 +42,8 @@ public final class SDAR1D {
     private final double[] _A;
     private double _mu;
     private double _sigma;
+    private double _muOld;
+    private double _sigmaOld;
 
     private boolean _initialized;
 
@@ -74,6 +76,10 @@ public final class SDAR1D {
             return 0.d;
         }
         Preconditions.checkArgument(k >= 1, "k MUST be greater than 0: ", k);
+
+        // old parameters are accessible to compute the Hellinger distance
+        this._muOld = _mu;
+        this._sigmaOld = _sigma;
 
         // update mean vector
         // \hat{mu} := (1-r) \hat{µ} + r x_t
@@ -115,4 +121,7 @@ public final class SDAR1D {
         return -Math.log(p);
     }
 
+    public double hellingerDistance() {
+        return MathUtils.hellingerDistance(_muOld, _sigmaOld, _mu, _sigma);
+    }
 }

--- a/core/src/main/java/hivemall/anomaly/SDAR2D.java
+++ b/core/src/main/java/hivemall/anomaly/SDAR2D.java
@@ -47,6 +47,8 @@ public final class SDAR2D {
     private final RealMatrix[] _C;
     private RealVector _mu;
     private RealMatrix _sigma;
+    private RealVector _muOld;
+    private RealMatrix _sigmaOld;
 
     private boolean _initialized;
 
@@ -82,6 +84,10 @@ public final class SDAR2D {
             return new ArrayRealVector(dims);
         }
         Preconditions.checkArgument(k >= 1, "k MUST be greater than 0: ", k);
+
+        // old parameters are accessible to compute the Hellinger distance
+        this._muOld = _mu.copy();
+        this._sigmaOld = _sigma.copy();
 
         // update mean vector
         // \hat{mu} := (1-r) \hat{µ} + r x_t
@@ -154,4 +160,7 @@ public final class SDAR2D {
         return -Math.log(p);
     }
 
+    public double hellingerDistance() {
+        return MathUtils.hellingerDistance(_muOld, _sigmaOld, _mu, _sigma);
+    }
 }

--- a/core/src/main/java/hivemall/utils/math/MathUtils.java
+++ b/core/src/main/java/hivemall/utils/math/MathUtils.java
@@ -41,6 +41,7 @@ import java.util.Random;
 import javax.annotation.Nonnull;
 
 import org.apache.commons.math3.linear.EigenDecomposition;
+import org.apache.commons.math3.linear.LUDecomposition;
 import org.apache.commons.math3.linear.RealMatrix;
 import org.apache.commons.math3.linear.RealVector;
 
@@ -361,6 +362,29 @@ public final class MathUtils {
         double numerator = Math.pow(sigma1, 0.25) * Math.pow(sigma2, 0.25) *
                 Math.exp(-0.25 * Math.pow(mu1 - mu2, 2) / sigmaSum);
         double denominator = Math.sqrt(sigmaSum / 2);
+        return 1.d - numerator / denominator;
+    }
+
+    /**
+     * @param mu1 mean vector of the first normal distribution
+     * @param sigma1 covariance matrix of the first normal distribution
+     * @param mu2 mean vector of the second normal distribution
+     * @param sigma2 covariance matrix of the second normal distribution
+     * @return the Hellinger distance between two multivariate normal distributions
+     * @link https://en.wikipedia.org/wiki/Hellinger_distance#Examples
+     */
+    public static double hellingerDistance(@Nonnull final RealVector mu1, @Nonnull final RealMatrix sigma1,
+                                           @Nonnull final RealVector mu2, @Nonnull final RealMatrix sigma2) {
+        RealVector muSub = mu1.subtract(mu2);
+        RealMatrix sigmaMean = sigma1.add(sigma2).scalarMultiply(0.5);
+        RealMatrix sigmaMeanInv = new LUDecomposition(sigmaMean).getSolver().getInverse();
+        double sigma1Det = new LUDecomposition(sigma1).getDeterminant();
+        double sigma2Det = new LUDecomposition(sigma2).getDeterminant();
+
+        double numerator = Math.pow(sigma1Det, 0.25) * Math.pow(sigma2Det, 0.25) *
+                Math.exp(-0.125 * sigmaMeanInv.preMultiply(muSub).dotProduct(muSub));
+        double denominator = Math.sqrt(new LUDecomposition(sigmaMean).getDeterminant());
+
         return 1.d - numerator / denominator;
     }
 

--- a/core/src/main/java/hivemall/utils/math/MathUtils.java
+++ b/core/src/main/java/hivemall/utils/math/MathUtils.java
@@ -343,4 +343,25 @@ public final class MathUtils {
 
         return numerator / denominator;
     }
+
+    /**
+     * @param mu1 mean of the first normal distribution
+     * @param sigma1 variance of the first normal distribution
+     * @param mu2 mean of the second normal distribution
+     * @param sigma2 variance of the second normal distribution
+     * @return the Hellinger distance between two normal distributions
+     * @link https://en.wikipedia.org/wiki/Hellinger_distance#Examples
+     */
+    public static double hellingerDistance(@Nonnull final double mu1, @Nonnull final double sigma1,
+                                           @Nonnull final double mu2, @Nonnull final double sigma2) {
+        double sigmaSum = sigma1 + sigma2;
+        if (sigmaSum == 0.d) {
+            return 0.d;
+        }
+        double numerator = Math.pow(sigma1, 0.25) * Math.pow(sigma2, 0.25) *
+                Math.exp(-0.25 * Math.pow(mu1 - mu2, 2) / sigmaSum);
+        double denominator = Math.sqrt(sigmaSum / 2);
+        return 1.d - numerator / denominator;
+    }
+
 }


### PR DESCRIPTION
### What this PR includes

By keeping the last `_mu` and `_sigma` in the SDAR algorithm as `_muOld` and `_sigmaOld`, we are now able to compute the Hellinger distance between the models before/after update. Usage is demonstrated as comments in **ChangeFinder1D** and **ChangeFinder2D**.

Computation of the Hellinger distance between two (multivariate) normal distributions are implemented on **MathUtils**.

### Are the Hellinger distances computed correctly?

Unit tests have not been implemented yet. However, I have confirmed whether it works as expected by comparing the results of [Python implementation](https://github.com/takuti/datadog-anomaly-detector/blob/e1c0523d8358a872fc3d59e28bb6c8411782934a/core/changefinder/changefinder_1d.py#L181-L202).

- mu1: 2.25635999045 
- sigma1: 1.56789907203 
- mu2: 2.37802392246
- sigma2: 4.5496514822

For the above parameters, the Python code returns a distance 0.0661275442145.

Here, our `MathUtils.hellingerDistanes()` method also works as:

```java
MathUtils.hellingerDistance(2.25635999045, 1.56789907203, 2.37802392246, 4.5496514822);
// => almost equal to 0.0661275442145
```

```java
RealVector mu1 = new ArrayRealVector(new double[] {2.25635999045});
RealMatrix sigma1 = new Array2DRowRealMatrix(new double[] {1.56789907203});
RealVector mu2 = new ArrayRealVector(new double[] {2.37802392246});
RealMatrix sigma2 = new Array2DRowRealMatrix(new double[] {4.5496514822});
MathUtils.hellingerDistance(mu1, sigma1, mu2, sigma2);
// => almost equal to 0.0661275442145
```