### PR TITLE
Fix spark version number for jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,26 @@
 					</systemPropertyVariables>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>1.8</version>
+				<executions>
+					<execution>
+						<id>regex-scala-property</id>
+						<goals>
+							<goal>regex-property</goal>
+						</goals>
+						<configuration>
+							<name>scala.version.parsed</name>
+							<value>${scala.version}</value>
+							<regex>(\d+\.\d+)\.\d+</regex>
+							<replacement>$1</replacement>
+							<failIfNoMatch>true</failIfNoMatch>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<!-- start coveralls -->
 			<plugin>
 				<groupId>org.eluder.coveralls</groupId>

--- a/spark/spark-1.6/pom.xml
+++ b/spark/spark-1.6/pom.xml
@@ -9,7 +9,7 @@
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
-	<artifactId>hivemall-spark-${spark.version}_${scala.version}</artifactId>
+	<artifactId>hivemall-spark</artifactId>
 	<name>Hivemall on Spark 1.6</name>
 	<packaging>jar</packaging>
 
@@ -96,9 +96,29 @@
 	<build>
 		<directory>target</directory>
 		<outputDirectory>target/classes</outputDirectory>
-		<finalName>${project.artifactId}-${project.version}</finalName>
+		<finalName>${project.artifactId}-${spark.version.parsed}_${scala.version.parsed}-${project.version}</finalName>
 		<testOutputDirectory>target/test-classes</testOutputDirectory>
 		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>1.8</version>
+				<executions>
+					<execution>
+						<id>regex-spark-property</id>
+						<goals>
+							<goal>regex-property</goal>
+						</goals>
+						<configuration>
+							<name>spark.version.parsed</name>
+							<value>${spark.version}</value>
+							<regex>(\d+\.\d+)\.\d+</regex>
+							<replacement>$1</replacement>
+							<failIfNoMatch>true</failIfNoMatch>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<!-- For incremental compilation -->
 			<plugin>
 				<groupId>net.alchim31.maven</groupId>
@@ -134,7 +154,7 @@
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>2.5</version>
 				<configuration>
-					<finalName>${project.artifactId}-${project.version}</finalName>
+					<finalName>${project.artifactId}-${spark.version.parsed}_${scala.version.parsed}-${project.version}</finalName>
 					<outputDirectory>${project.parent.build.directory}</outputDirectory>
 				</configuration>
 			</plugin>
@@ -151,7 +171,7 @@
 							<goal>shade</goal>
 						</goals>
 						<configuration>
-							<finalName>${project.artifactId}-${project.version}-with-dependencies</finalName>
+							<finalName>${project.artifactId}-${spark.version.parsed}_${scala.version.parsed}-${project.version}-with-dependencies</finalName>
 							<outputDirectory>${project.parent.build.directory}</outputDirectory>
 							<minimizeJar>false</minimizeJar>
 							<createDependencyReducedPom>false</createDependencyReducedPom>

--- a/spark/spark-2.0/pom.xml
+++ b/spark/spark-2.0/pom.xml
@@ -9,7 +9,7 @@
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
-	<artifactId>hivemall-spark-${spark.version}_${scala.version}</artifactId>
+	<artifactId>hivemall-spark</artifactId>
 	<name>Hivemall on Spark 2.0</name>
 	<packaging>jar</packaging>
 
@@ -102,9 +102,29 @@
 	<build>
 		<directory>target</directory>
 		<outputDirectory>target/classes</outputDirectory>
-		<finalName>${project.artifactId}-${project.version}</finalName>
+		<finalName>${project.artifactId}-${spark.version.parsed}_${scala.version.parsed}-${project.version}</finalName>
 		<testOutputDirectory>target/test-classes</testOutputDirectory>
 		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>1.8</version>
+				<executions>
+					<execution>
+						<id>regex-spark-property</id>
+						<goals>
+							<goal>regex-property</goal>
+						</goals>
+						<configuration>
+							<name>spark.version.parsed</name>
+							<value>${spark.version}</value>
+							<regex>(\d+\.\d+)\.\d+</regex>
+							<replacement>$1</replacement>
+							<failIfNoMatch>true</failIfNoMatch>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<!-- For incremental compilation -->
 			<plugin>
 				<groupId>net.alchim31.maven</groupId>
@@ -140,7 +160,7 @@
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>2.5</version>
 				<configuration>
-					<finalName>${project.artifactId}-${project.version}</finalName>
+					<finalName>${project.artifactId}-${spark.version.parsed}_${scala.version.parsed}-${project.version}</finalName>
 					<outputDirectory>${project.parent.build.directory}</outputDirectory>
 				</configuration>
 			</plugin>
@@ -157,7 +177,7 @@
 							<goal>shade</goal>
 						</goals>
 						<configuration>
-							<finalName>${project.artifactId}-${project.version}-with-dependencies</finalName>
+							<finalName>${project.artifactId}-${spark.version.parsed}_${scala.version.parsed}-${project.version}-with-dependencies</finalName>
 							<outputDirectory>${project.parent.build.directory}</outputDirectory>
 							<minimizeJar>false</minimizeJar>
 							<createDependencyReducedPom>false</createDependencyReducedPom>


### PR DESCRIPTION
This pr is to remove an unnecessary suffix number in jar from `hivemall-spark-2.0.0_2.11.8-0.4.2-rc.2-with-dependencies.jar` to `hivemall-spark-2.0_2.11-0.4.2-rc.2-with-dependencies.jar`.