### PR TITLE
Add checkstyle at compile time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -322,7 +322,7 @@
 					<dependency>
 						<groupId>com.puppycrawl.tools</groupId>
 						<artifactId>checkstyle</artifactId>
-						<version>7.1.1</version>
+						<version>6.11.2</version>
 					</dependency>
 					<dependency>
 						<groupId>com.google.guava</groupId>
@@ -339,7 +339,7 @@
 					</execution>
 				</executions>
 				<configuration>
-					<configLocation>google_checks.xml</configLocation>
+					<configLocation>resources/hivemall-checkstyle.xml</configLocation>
 					<encoding>UTF-8</encoding>
 					<consoleOutput>true</consoleOutput>
 					<failsOnError>true</failsOnError>

--- a/pom.xml
+++ b/pom.xml
@@ -314,6 +314,44 @@
 				</configuration>
 			</plugin>
 			<!-- end sonatype deploy -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>2.17</version>
+				<dependencies>
+					<dependency>
+						<groupId>com.puppycrawl.tools</groupId>
+						<artifactId>checkstyle</artifactId>
+						<version>7.1.1</version>
+					</dependency>
+					<dependency>
+						<groupId>com.google.guava</groupId>
+						<artifactId>guava</artifactId>
+						<version>19.0</version>
+					</dependency>
+				</dependencies>
+				<executions>
+					<execution>
+						<phase>compile</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<configLocation>google_checks.xml</configLocation>
+					<encoding>UTF-8</encoding>
+					<consoleOutput>true</consoleOutput>
+					<failsOnError>true</failsOnError>
+					<!-- enabling this after refactoring of making coding style consistent -->
+					<!-- <failOnViolation>true</failOnViolation> -->
+					<!-- <violationSeverity>warning</violationSeverity> -->
+					<format>xml</format>
+					<format>html</format>
+					<outputFile>${project.build.directory}/test/checkstyle-errors.xml</outputFile>
+					<linkXRef>false</linkXRef>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
This PR enables compile-time coding style check by using maven-checkstyle-plugin.

Please run:

```
$ mvn clean compile
```

and it shows you the warning and error messages, based on Google Java Coding Style in maven-checkstyle-plugin: http://checkstyle.sourceforge.net/google_style.html

https://google.github.io/styleguide/javaguide.html
