### PR TITLE
Add benchmark code for each_top_k

### DIFF
--- a/spark/spark-1.6/src/main/scala/org/apache/spark/sql/hive/HivemallOps.scala
+++ b/spark/spark-1.6/src/main/scala/org/apache/spark/sql/hive/HivemallOps.scala
@@ -640,13 +640,13 @@ final class HivemallOps(df: DataFrame) extends Logging {
    * @group misc
    */
   def each_top_k(k: Column, group: Column, value: Column, args: Column*): DataFrame = {
+    val clusterDf = df.repartition(group).sortWithinPartitions(group)
     Generate(HiveGenericUDTF(
       new HiveFunctionWrapper("hivemall.tools.EachTopKUDTF"),
       (Seq(k, group, value) ++ args).map(_.expr)),
     join = false, outer = false, None,
     (Seq("rank", "key") ++ args.map(_.named.name)).map(UnresolvedAttribute(_)),
-    // Repartition rows by the given `group` column
-    df.repartition(group).logicalPlan)
+    clusterDf.logicalPlan)
   }
 
   /**

--- a/spark/spark-1.6/src/test/scala/org/apache/spark/sql/hive/HivemallOpsSuite.scala
+++ b/spark/spark-1.6/src/test/scala/org/apache/spark/sql/hive/HivemallOpsSuite.scala
@@ -281,11 +281,11 @@ final class HivemallOpsSuite extends HivemallQueryTest {
       // TODO: Use `toDF`
       val rowRdd = hiveContext.sparkContext.parallelize(
           Row("a", "1", 0.5) ::
-          Row("a", "2", 0.6) ::
-          Row("a", "3", 0.8) ::
-          Row("b", "4", 0.3) ::
           Row("b", "5", 0.1) ::
+          Row("a", "3", 0.8) ::
           Row("c", "6", 0.3) ::
+          Row("b", "4", 0.3) ::
+          Row("a", "2", 0.6) ::
           Nil
         )
       hiveContext.createDataFrame(

--- a/spark/spark-2.0/src/test/scala/org/apache/spark/sql/hive/HivemallOpsSuite.scala
+++ b/spark/spark-2.0/src/test/scala/org/apache/spark/sql/hive/HivemallOpsSuite.scala
@@ -282,11 +282,11 @@ final class HivemallOpsWithFeatureSuite extends HivemallFeatureQueryTest {
       // TODO: Use `toDF`
       val rowRdd = hiveContext.sparkContext.parallelize(
           Row("a", "1", 0.5) ::
-          Row("a", "2", 0.6) ::
-          Row("a", "3", 0.8) ::
-          Row("b", "4", 0.3) ::
           Row("b", "5", 0.1) ::
+          Row("a", "3", 0.8) ::
           Row("c", "6", 0.3) ::
+          Row("b", "4", 0.3) ::
+          Row("a", "2", 0.6) ::
           Nil
         )
       hiveContext.createDataFrame(
@@ -300,8 +300,9 @@ final class HivemallOpsWithFeatureSuite extends HivemallFeatureQueryTest {
     }
 
     // Compute top-1 rows for each group
-    val top1 = groupedData.each_top_k(
-      1, groupedData.col("group"), groupedData.col("value"), groupedData.col("attr"))
+    val top1 = groupedData
+      .repartition("group")
+      .each_top_k(1, groupedData.col("group"), groupedData.col("value"), groupedData.col("attr"))
 
     assert(top1.select(top1.col("attr")).collect.toSet ===
       Set(Row("3"), Row("4"), Row("6")))


### PR DESCRIPTION
FYI: The results are as follows;
```
Java HotSpot(TM) 64-Bit Server VM 1.8.0_31-b13 on Mac OS X 10.10.2
Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz

top-k (k=8):            Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------
rank                       57267 / 59267          0.5        2184.5       1.0X
each_top_k                 40415 / 44812          0.6        1541.7       1.4X
```