### PR TITLE
[WIP] Implement EachTopK as a generator expression

### DIFF
--- a/spark/spark-2.0/src/main/scala/org/apache/spark/sql/catalyst/expressions/EachTopK.scala
+++ b/spark/spark-2.0/src/main/scala/org/apache/spark/sql/catalyst/expressions/EachTopK.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.types._
+import org.apache.spark.util.BoundedPriorityQueue
+
+case class EachTopK(k: Int, children: Seq[Expression]) extends Generator with CodegenFallback {
+
+  private def getKey(d: (Double, InternalRow)) = d._1
+
+  private[this] val queue: BoundedPriorityQueue[(Double, InternalRow)] =
+    new BoundedPriorityQueue(k)(Ordering.by(getKey))
+  private[this] var prevGroup: Int = -1
+
+  override def checkInputDataTypes(): TypeCheckResult = {
+    if (children.size > 1 && children(1).dataType == DoubleType) {
+      TypeCheckResult.TypeCheckSuccess
+    } else {
+      TypeCheckResult.TypeCheckFailure(
+        "the second column must have double-typed data, "
+          + s"however: ${children(1).dataType}")
+    }
+  }
+
+  override def elementSchema: StructType =
+    StructType(
+      Seq(StructField("rank", IntegerType)) ++
+        children.map(d => StructField(d.prettyName, d.dataType))
+    )
+
+  override def eval(input: InternalRow): TraversableOnce[InternalRow] = {
+    val ret = if (prevGroup != input.getInt(0) && queue.size > 0) {
+      val iter = queue.iterator.toSeq.sortBy(_._1)(Ordering[Double].reverse)
+          .zipWithIndex.map { case ((_, row), index) =>
+        new JoinedRow(InternalRow(index), row)
+      }
+      queue.clear()
+      iter
+    } else {
+      Seq.empty[InternalRow]
+    }
+    queue += Tuple2(input.getDouble(1), input.copy())
+    prevGroup = input.getInt(0)
+    ret
+  }
+
+  override def terminate(): TraversableOnce[InternalRow] = {
+    if (queue.size > 0) {
+      val d = queue.iterator.toSeq.sortBy(_._1)(Ordering[Double].reverse)
+          .zipWithIndex.map { case ((_, row), index) =>
+        new JoinedRow(InternalRow(index), row)
+      }.toSeq
+      queue.clear()
+      d
+    } else {
+      Iterator.empty
+    }
+  }
+}

--- a/spark/spark-2.0/src/main/scala/org/apache/spark/sql/hive/HivemallOps.scala
+++ b/spark/spark-2.0/src/main/scala/org/apache/spark/sql/hive/HivemallOps.scala
@@ -825,12 +825,12 @@ final class HivemallOps(df: DataFrame) extends Logging {
     : DataFrame = withTypedPlan {
     val clusterDf = df.repartition(group).sortWithinPartitions(group)
     Generate(HiveGenericUDTF(
-      "each_top_k",
-      new HiveFunctionWrapper("hivemall.tools.EachTopKUDTF"),
-      (Seq(k, group, value) ++ args).map(_.expr)),
-    join = false, outer = false, None,
-    (Seq("rank", "key") ++ args.map(_.named.name)).map(UnresolvedAttribute(_)),
-    clusterDf.logicalPlan)
+        "each_top_k",
+        new HiveFunctionWrapper("hivemall.tools.EachTopKUDTF"),
+        (Seq(k, group, value) ++ args).map(_.expr)),
+      join = false, outer = false, None,
+      (Seq("rank", "key") ++ args.map(_.named.name)).map(UnresolvedAttribute(_)),
+      clusterDf.logicalPlan)
   }
 
   /**


### PR DESCRIPTION
I'm working on more efficient top-k processing on DataFrame/Spark.
The current performance results are as follows;
```
Java HotSpot(TM) 64-Bit Server VM 1.8.0_31-b13 on Mac OS X 10.10.2
Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz

top-k (k=100):                           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------
rank                                        58497 / 59431          0.4        2231.5       1.0X
each_top_k (hive-udf)                       41123 / 41298          0.6        1568.7       1.4X
each_top_k (exprs)                          14651 / 14989          1.8         558.9       4.0X
```