### PR TITLE
Implement EachTopK as a generator expression

### DIFF
--- a/spark/spark-2.0/src/main/scala/org/apache/spark/sql/catalyst/expressions/EachTopK.scala
+++ b/spark/spark-2.0/src/main/scala/org/apache/spark/sql/catalyst/expressions/EachTopK.scala
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.catalyst.util.TypeUtils
+import org.apache.spark.sql.types._
+import org.apache.spark.util.BoundedPriorityQueue
+
+case class EachTopK(
+    k: Int,
+    groupingExpression: Expression,
+    scoreExpression: Expression,
+    children: Seq[Attribute]) extends Generator with CodegenFallback {
+  type QueueType = (AnyRef, InternalRow)
+
+  require(k != 0, "`k` must not have 0")
+
+  private[this] lazy val scoreType = scoreExpression.dataType
+  private[this] lazy val scoreOrdering = {
+    val ordering = TypeUtils.getInterpretedOrdering(scoreType)
+      .asInstanceOf[Ordering[AnyRef]]
+    if (k > 0) {
+      ordering
+    } else {
+      ordering.reverse
+    }
+  }
+  private[this] lazy val reverseScoreOrdering = scoreOrdering.reverse
+
+  private[this] val queue: BoundedPriorityQueue[QueueType] = {
+    new BoundedPriorityQueue(Math.abs(k))(new Ordering[QueueType] {
+      override def compare(x: QueueType, y: QueueType): Int =
+        scoreOrdering.compare(x._1, y._1)
+    })
+  }
+
+  lazy private[this] val groupingProjection: UnsafeProjection =
+    UnsafeProjection.create(groupingExpression :: Nil, children)
+
+  lazy private[this] val scoreProjection: UnsafeProjection =
+    UnsafeProjection.create(scoreExpression :: Nil, children)
+
+  // The grouping key of the current partition
+  private[this] var currentGroupingKey: UnsafeRow = _
+
+  override def checkInputDataTypes(): TypeCheckResult = {
+    if (!TypeCollection.Ordered.acceptsType(scoreExpression.dataType)) {
+      TypeCheckResult.TypeCheckFailure(
+        s"$scoreExpression must have a comparable type")
+    } else {
+      TypeCheckResult.TypeCheckSuccess
+    }
+  }
+
+  override def elementSchema: StructType =
+    StructType(
+      Seq(StructField("rank", IntegerType)) ++
+        children.map(d => StructField(d.prettyName, d.dataType))
+    )
+
+  override def eval(input: InternalRow): TraversableOnce[InternalRow] = {
+    val groupingKey = groupingProjection(input)
+    val ret = if (currentGroupingKey != groupingKey) {
+      val part = queue.iterator.toSeq.sortBy(_._1)(reverseScoreOrdering)
+          .zipWithIndex.map { case ((_, row), index) =>
+        new JoinedRow(InternalRow(1 + index), row)
+      }
+      currentGroupingKey = groupingKey.copy()
+      queue.clear()
+      part
+    } else {
+      Iterator.empty
+    }
+    queue += Tuple2(scoreProjection(input).get(0, scoreType), input.copy())
+    ret
+  }
+
+  override def terminate(): TraversableOnce[InternalRow] = {
+    if (queue.size > 0) {
+      val part = queue.iterator.toSeq.sortBy(_._1)(reverseScoreOrdering)
+          .zipWithIndex.map { case ((_, row), index) =>
+        new JoinedRow(InternalRow(1 + index), row)
+      }
+      queue.clear()
+      part
+    } else {
+      Iterator.empty
+    }
+  }
+}

--- a/spark/spark-2.0/src/test/scala/org/apache/spark/sql/hive/HiveUdfSuite.scala
+++ b/spark/spark-2.0/src/test/scala/org/apache/spark/sql/hive/HiveUdfSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.hive
 
-import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.hive.HivemallUtils._
 import org.apache.spark.test.HivemallFeatureQueryTest
@@ -43,7 +42,7 @@ final class HiveUdfWithFeatureSuite extends HivemallFeatureQueryTest {
   }
 
   test("train_logregr") {
-    TinyTrainData.registerTempTable("TinyTrainData")
+    TinyTrainData.createOrReplaceTempView("TinyTrainData")
     sql(s"""
          | CREATE TEMPORARY FUNCTION train_logregr
          |   AS '${classOf[hivemall.regression.LogressUDTF].getName}'
@@ -75,13 +74,49 @@ final class HiveUdfWithFeatureSuite extends HivemallFeatureQueryTest {
     // hiveContext.sql("DROP TEMPORARY FUNCTION IF EXISTS train_logregr")
     // hiveContext.reset()
   }
+
+  test("each_top_k") {
+    val testDf = Seq(
+      ("a", "1", 0.5, Array(0, 1, 2)),
+      ("b", "5", 0.1, Array(3)),
+      ("a", "3", 0.8, Array(2, 5)),
+      ("c", "6", 0.3, Array(1, 3)),
+      ("b", "4", 0.3, Array(2)),
+      ("a", "2", 0.6, Array(1))
+    ).toDF("key", "value", "score", "data")
+
+    import testDf.sqlContext.implicits._
+    testDf.repartition($"key").sortWithinPartitions($"key").createOrReplaceTempView("TestData")
+    sql(s"""
+         | CREATE TEMPORARY FUNCTION each_top_k
+         |   AS '${classOf[hivemall.tools.EachTopKUDTF].getName}'
+       """.stripMargin)
+
+    // Compute top-1 rows for each group
+    checkAnswer(
+      sql("SELECT each_top_k(1, key, score, key, value) FROM TestData"),
+      Row(1, 0.8, "a", "3") ::
+      Row(1, 0.3, "b", "4") ::
+      Row(1, 0.3, "c", "6") ::
+      Nil
+    )
+
+    // Compute reverse top-1 rows for each group
+    checkAnswer(
+      sql("SELECT each_top_k(-1, key, score, key, value) FROM TestData"),
+      Row(1, 0.5, "a", "1") ::
+      Row(1, 0.1, "b", "5") ::
+      Row(1, 0.3, "c", "6") ::
+      Nil
+    )
+  }
 }
 
 final class HiveUdfWithVectorSuite extends VectorQueryTest {
   import hiveContext._
 
   test("to_hivemall_features") {
-    mllibTrainDf.registerTempTable("mllibTrainDf")
+    mllibTrainDf.createOrReplaceTempView("mllibTrainDf")
     hiveContext.udf.register("to_hivemall_features", _to_hivemall_features)
     checkAnswer(
       sql(
@@ -99,7 +134,7 @@ final class HiveUdfWithVectorSuite extends VectorQueryTest {
   }
 
   ignore("append_bias") {
-    mllibTrainDf.registerTempTable("mllibTrainDf")
+    mllibTrainDf.createOrReplaceTempView("mllibTrainDf")
     hiveContext.udf.register("append_bias", _append_bias)
     hiveContext.udf.register("to_hivemall_features", _to_hivemall_features)
     /**

--- a/spark/spark-2.0/src/test/scala/org/apache/spark/sql/hive/benchmark/MiscBenchmark.scala
+++ b/spark/spark-2.0/src/test/scala/org/apache/spark/sql/hive/benchmark/MiscBenchmark.scala
@@ -21,13 +21,13 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
-import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.catalyst.plans.logical.{Generate, LogicalPlan}
+import org.apache.spark.sql.catalyst.expressions.{EachTopK, Expression}
+import org.apache.spark.sql.catalyst.plans.logical.{Generate, LogicalPlan, Project}
 import org.apache.spark.sql.expressions.Window
+import org.apache.spark.sql.functions._
 import org.apache.spark.sql.hive.HiveGenericUDTF
 import org.apache.spark.sql.{Column, DataFrame, Row, SparkSession, functions}
 import org.apache.spark.sql.catalyst.expressions.Literal
-import org.apache.spark.sql.functions._
 import org.apache.spark.sql.hive.HiveGenericUDF
 import org.apache.spark.sql.hive.HiveShim.HiveFunctionWrapper
 import org.apache.spark.sql.types._
@@ -36,18 +36,37 @@ import org.apache.spark.util.Benchmark
 
 import org.apache.spark.sql.hive.HivemallUtils._
 
-class HiveFuncWrapper(df: DataFrame) {
+class TestFuncWrapper(df: DataFrame) {
 
   def each_top_k(k: Column, group: Column, value: Column, args: Column*)
     : DataFrame = withTypedPlan {
-    val clusterDf= df.repartition(group).sortWithinPartitions(group)
+    val clusterDf = df.repartition(group).sortWithinPartitions(group)
     Generate(HiveGenericUDTF(
-      "each_top_k",
-      new HiveFunctionWrapper("hivemall.tools.EachTopKUDTF"),
-      (Seq(k, group, value) ++ args).map(_.expr)),
-    join = false, outer = false, None,
-    (Seq("rank", "key") ++ args.map(_.named.name)).map(UnresolvedAttribute(_)),
-    clusterDf.logicalPlan)
+        "each_top_k",
+        new HiveFunctionWrapper("hivemall.tools.EachTopKUDTF"),
+        (Seq(k, group, value) ++ args).map(_.expr)),
+      join = false, outer = false, None,
+      (Seq("rank", "key") ++ args.map(_.named.name)).map(UnresolvedAttribute(_)),
+      clusterDf.logicalPlan)
+  }
+
+  def each_top_k_improved(k: Int, group: String, score: String, args: String*)
+    : DataFrame = withTypedPlan {
+    val clusterDf = df.repartition(group).sortWithinPartitions(group)
+    val childrenAttributes = clusterDf.logicalPlan.output
+    val generator = Generate(
+      EachTopK(
+        k,
+        clusterDf.resolve(group),
+        clusterDf.resolve(score),
+        childrenAttributes
+      ),
+      join = false, outer = false, None,
+      (Seq("rank") ++ childrenAttributes.map(_.name)).map(UnresolvedAttribute(_)),
+      clusterDf.logicalPlan)
+    val attributes = generator.generatedSet
+    val projectList = (Seq("rank") ++ args).map(s => attributes.find(_.name == s).get)
+    Project(projectList, generator)
   }
 
   /**
@@ -60,13 +79,13 @@ class HiveFuncWrapper(df: DataFrame) {
   }
 }
 
-object HiveFuncWrapper {
+object TestFuncWrapper {
 
   /**
-   * Implicitly inject the [[HiveFuncWrapper]] into [[DataFrame]].
+   * Implicitly inject the [[TestFuncWrapper]] into [[DataFrame]].
    */
-  implicit def dataFrameToHiveFuncWrapper(df: DataFrame): HiveFuncWrapper =
-    new HiveFuncWrapper(df)
+  implicit def dataFrameToTestFuncWrapper(df: DataFrame): TestFuncWrapper =
+    new TestFuncWrapper(df)
 
   def sigmoid(exprs: Column*): Column = withExpr {
     HiveGenericUDF("sigmoid",
@@ -144,7 +163,7 @@ class MiscBenchmark extends SparkFunSuite {
     )
     addBenchmarkCase(
       "hive-udf",
-      testDf.select(HiveFuncWrapper.sigmoid($"value"))
+      testDf.select(TestFuncWrapper.sigmoid($"value"))
     )
 
     benchmark.run()
@@ -152,18 +171,16 @@ class MiscBenchmark extends SparkFunSuite {
 
   TestUtils.benchmark("top-k query") {
     /**
-     * Java HotSpot(TM) 64-Bit Server VM 1.8.0_31-b13 on Mac OS X 10.10.2
-     * Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz
-     *
-     * top-k (k=8):            Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+     * top-k (k=100):          Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
      * -------------------------------------------------------------------------------
-     * rank                       57267 / 59267          0.5        2184.5       1.0X
-     * each_top_k                 40415 / 44812          0.6        1541.7       1.4X
+     * rank                       62748 / 62862          0.4        2393.6       1.0X
+     * each_top_k (hive-udf)      41421 / 41736          0.6        1580.1       1.5X
+     * each_top_k (exprs)         15793 / 16394          1.7         602.5       4.0X
      */
     import sparkSession.sqlContext.implicits._
-    import HiveFuncWrapper._
+    import TestFuncWrapper._
     val N = 100L << 18
-    val topK = 8
+    val topK = 100
     val numGroup = 3
     implicit val benchmark = new Benchmark(s"top-k (k=$topK)", N)
     val schema = StructType(
@@ -192,13 +209,18 @@ class MiscBenchmark extends SparkFunSuite {
     )
 
     addBenchmarkCase(
-      "each_top_k",
+      "each_top_k (hive-udf)",
       // TODO: If $"value" given, it throws `AnalysisException`. Why?
       // testDf.each_top_k(10, $"key", $"score", $"value")
       // org.apache.spark.sql.catalyst.analysis.UnresolvedException: Invalid call to name
       //   on unresolved object, tree: unresolvedalias('value, None)
       // at org.apache.spark.sql.catalyst.analysis.UnresolvedAlias.name(unresolved.scala:339)
       testDf.each_top_k(topK, $"key", $"score", testDf("value"))
+    )
+
+    addBenchmarkCase(
+      "each_top_k (exprs)",
+      testDf.each_top_k_improved(topK, "key", "score", "value")
     )
 
     benchmark.run()


### PR DESCRIPTION
This pr is to implement more efficient top-k processing on DataFrame/Spark.
The final benchmark results are as follows;
```
top-k (k=100):                           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------
rank                                        62748 / 62862          0.4        2393.6       1.0X
each_top_k (hive-udf)                       41421 / 41736          0.6        1580.1       1.5X
each_top_k (exprs)                          15793 / 16394          1.7         602.5       4.0X
```