### PR TITLE
Brush up spark/pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
 		<protoc.path>${env.PROTOC_PATH}</protoc.path>
 		<hive.version>0.13.0</hive.version>
 		<scala.version>2.11.8</scala.version>
+		<scala.binary.version>2.11</scala.binary.version>
 	</properties>
 
 	<repositories>
@@ -80,6 +81,7 @@
 			</modules>
 			<properties>
 				<spark.version>2.0.0</spark.version>
+				<spark.binary.version>2.0</spark.binary.version>
 			</properties>
 		</profile>
 		<profile>
@@ -90,6 +92,7 @@
 			</modules>
 			<properties>
 				<spark.version>1.6.2</spark.version>
+				<spark.binary.version>1.6</spark.binary.version>
 			</properties>
 		</profile>
 		<profile>
@@ -259,26 +262,6 @@
 						<java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
 					</systemPropertyVariables>
 				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>1.8</version>
-				<executions>
-					<execution>
-						<id>regex-scala-property</id>
-						<goals>
-							<goal>regex-property</goal>
-						</goals>
-						<configuration>
-							<name>scala.version.parsed</name>
-							<value>${scala.version}</value>
-							<regex>(\d+\.\d+)\.\d+</regex>
-							<replacement>$1</replacement>
-							<failIfNoMatch>true</failIfNoMatch>
-						</configuration>
-					</execution>
-				</executions>
 			</plugin>
 			<!-- start coveralls -->
 			<plugin>

--- a/spark/spark-1.6/pom.xml
+++ b/spark/spark-1.6/pom.xml
@@ -13,6 +13,12 @@
 	<name>Hivemall on Spark 1.6</name>
 	<packaging>jar</packaging>
 
+	<properties>
+		<PermGen>64m</PermGen>
+		<MaxPermGen>1024m</MaxPermGen>
+		<CodeCacheSize>512m</CodeCacheSize>
+	</properties>
+
 	<dependencies>
 		<!-- hivemall dependencies -->
 		<dependency>
@@ -28,7 +34,7 @@
 			<scope>compile</scope>
 		</dependency>
 
-		<!-- other third-party dependencies -->
+		<!-- third-party dependencies -->
 		<dependency>
 			<groupId>org.scala-lang</groupId>
 			<artifactId>scala-library</artifactId>
@@ -36,40 +42,42 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-core_2.11</artifactId>
-			<version>${spark.version}</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-sql_2.11</artifactId>
-			<version>${spark.version}</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-hive_2.11</artifactId>
-			<version>${spark.version}</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-streaming_2.11</artifactId>
-			<version>${spark.version}</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-mllib_2.11</artifactId>
-			<version>${spark.version}</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
 			<version>1.8</version>
 			<scope>compile</scope>
+		</dependency>
+
+		<!-- other provided dependencies -->
+		<dependency>
+			<groupId>org.apache.spark</groupId>
+			<artifactId>spark-core_${scala.binary.version}</artifactId>
+			<version>${spark.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.spark</groupId>
+			<artifactId>spark-sql_${scala.binary.version}</artifactId>
+			<version>${spark.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.spark</groupId>
+			<artifactId>spark-hive_${scala.binary.version}</artifactId>
+			<version>${spark.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.spark</groupId>
+			<artifactId>spark-streaming_${scala.binary.version}</artifactId>
+			<version>${spark.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.spark</groupId>
+			<artifactId>spark-mllib_${scala.binary.version}</artifactId>
+			<version>${spark.version}</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- test dependencies -->
@@ -87,7 +95,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.scalatest</groupId>
-			<artifactId>scalatest_2.11</artifactId>
+			<artifactId>scalatest_${scala.binary.version}</artifactId>
 			<version>2.2.4</version>
 			<scope>test</scope>
 		</dependency>
@@ -96,29 +104,9 @@
 	<build>
 		<directory>target</directory>
 		<outputDirectory>target/classes</outputDirectory>
-		<finalName>${project.artifactId}-${spark.version.parsed}_${scala.version.parsed}-${project.version}</finalName>
+		<finalName>${project.artifactId}-${spark.binary.version}_${scala.binary.version}-${project.version}</finalName>
 		<testOutputDirectory>target/test-classes</testOutputDirectory>
 		<plugins>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>1.8</version>
-				<executions>
-					<execution>
-						<id>regex-spark-property</id>
-						<goals>
-							<goal>regex-property</goal>
-						</goals>
-						<configuration>
-							<name>spark.version.parsed</name>
-							<value>${spark.version}</value>
-							<regex>(\d+\.\d+)\.\d+</regex>
-							<replacement>$1</replacement>
-							<failIfNoMatch>true</failIfNoMatch>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 			<!-- For incremental compilation -->
 			<plugin>
 				<groupId>net.alchim31.maven</groupId>
@@ -126,8 +114,16 @@
 				<version>3.2.2</version>
 				<executions>
 					<execution>
+						<id>scala-compile-first</id>
+						<phase>process-resources</phase>
 						<goals>
 							<goal>compile</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>scala-test-compile-first</id>
+						<phase>process-test-resources</phase>
+						<goals>
 							<goal>testCompile</goal>
 						</goals>
 					</execution>
@@ -145,20 +141,23 @@
 					<jvmArgs>
 						<jvmArg>-Xms1024m</jvmArg>
 						<jvmArg>-Xmx1024m</jvmArg>
+						<jvmArg>-XX:PermSize=${PermGen}</jvmArg>
+						<jvmArg>-XX:MaxPermSize=${MaxPermGen}</jvmArg>
+						<jvmArg>-XX:ReservedCodeCacheSize=${CodeCacheSize}</jvmArg>
 					</jvmArgs>
 				</configuration>
 			</plugin>
-			<!-- hivemall-spark_2.11-xx.jar -->
+			<!-- hivemall-spark_xx-xx.jar -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>2.5</version>
 				<configuration>
-					<finalName>${project.artifactId}-${spark.version.parsed}_${scala.version.parsed}-${project.version}</finalName>
+					<finalName>${project.artifactId}-${spark.binary.version}_${scala.binary.version}-${project.version}</finalName>
 					<outputDirectory>${project.parent.build.directory}</outputDirectory>
 				</configuration>
 			</plugin>
-			<!-- hivemall-spark_2.11-xx-with-dependencies.jar including minimum dependencies -->
+			<!-- hivemall-spark_xx-xx-with-dependencies.jar including minimum dependencies -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
@@ -171,7 +170,7 @@
 							<goal>shade</goal>
 						</goals>
 						<configuration>
-							<finalName>${project.artifactId}-${spark.version.parsed}_${scala.version.parsed}-${project.version}-with-dependencies</finalName>
+							<finalName>${project.artifactId}-${spark.binary.version}_${scala.binary.version}-${project.version}-with-dependencies</finalName>
 							<outputDirectory>${project.parent.build.directory}</outputDirectory>
 							<minimizeJar>false</minimizeJar>
 							<createDependencyReducedPom>false</createDependencyReducedPom>
@@ -188,7 +187,7 @@
 					</execution>
 				</executions>
 			</plugin>
-			<!-- disable surefire -->
+			<!-- disable surefire because there is no java test -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
@@ -202,11 +201,32 @@
 				<groupId>org.scalatest</groupId>
 				<artifactId>scalatest-maven-plugin</artifactId>
 				<version>1.0</version>
+				<!-- Note config is repeated in surefire config -->
 				<configuration>
 					<reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
 					<junitxml>.</junitxml>
-					<filereports>WDF TestSuite.txt</filereports>
-					<argLine>-Xms256m -Xmx1024m -XX:MaxPermSize=1024m -XX:+CMSClassUnloadingEnabled</argLine>
+					<filereports>SparkTestSuite.txt</filereports>
+					<argLine>-ea -Xmx3g -XX:MaxPermSize=${MaxPermGen} -XX:ReservedCodeCacheSize=${CodeCacheSize}</argLine>
+					<stderr/>
+					<environmentVariables>
+						<SPARK_PREPEND_CLASSES>1</SPARK_PREPEND_CLASSES>
+						<SPARK_SCALA_VERSION>${scala.binary.version}</SPARK_SCALA_VERSION>
+						<SPARK_TESTING>1</SPARK_TESTING>
+						<JAVA_HOME>${env.JAVA_HOME}</JAVA_HOME>
+					</environmentVariables>
+					<systemProperties>
+						<log4j.configuration>file:src/test/resources/log4j.properties</log4j.configuration>
+						<derby.system.durability>test</derby.system.durability>
+						<java.awt.headless>true</java.awt.headless>
+						<java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>
+						<spark.testing>1</spark.testing>
+						<spark.ui.enabled>false</spark.ui.enabled>
+						<spark.ui.showConsoleProgress>false</spark.ui.showConsoleProgress>
+						<spark.unsafe.exceptionOnMemoryLeak>true</spark.unsafe.exceptionOnMemoryLeak>
+						<!-- Needed by sql/hive tests. -->
+						<test.src.tables>__not_used__</test.src.tables>
+					</systemProperties>
+					<tagsToExclude>${test.exclude.tags}</tagsToExclude>
 				</configuration>
 				<executions>
 					<execution>

--- a/spark/spark-2.0/pom.xml
+++ b/spark/spark-2.0/pom.xml
@@ -13,6 +13,12 @@
 	<name>Hivemall on Spark 2.0</name>
 	<packaging>jar</packaging>
 
+	<properties>
+		<PermGen>64m</PermGen>
+		<MaxPermGen>1024m</MaxPermGen>
+		<CodeCacheSize>512m</CodeCacheSize>
+	</properties>
+
 	<dependencies>
 		<!-- hivemall dependencies -->
 		<dependency>
@@ -34,7 +40,7 @@
 			<scope>compile</scope>
 		</dependency>
 
-		<!-- other third-party dependencies -->
+		<!-- third-party dependencies -->
 		<dependency>
 			<groupId>org.scala-lang</groupId>
 			<artifactId>scala-library</artifactId>
@@ -42,40 +48,42 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-core_2.11</artifactId>
-			<version>${spark.version}</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-sql_2.11</artifactId>
-			<version>${spark.version}</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-hive_2.11</artifactId>
-			<version>${spark.version}</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-streaming_2.11</artifactId>
-			<version>${spark.version}</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-mllib_2.11</artifactId>
-			<version>${spark.version}</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
 			<version>1.8</version>
 			<scope>compile</scope>
+		</dependency>
+
+		<!-- other provided dependencies -->
+		<dependency>
+			<groupId>org.apache.spark</groupId>
+			<artifactId>spark-core_${scala.binary.version}</artifactId>
+			<version>${spark.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.spark</groupId>
+			<artifactId>spark-sql_${scala.binary.version}</artifactId>
+			<version>${spark.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.spark</groupId>
+			<artifactId>spark-hive_${scala.binary.version}</artifactId>
+			<version>${spark.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.spark</groupId>
+			<artifactId>spark-streaming_${scala.binary.version}</artifactId>
+			<version>${spark.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.spark</groupId>
+			<artifactId>spark-mllib_${scala.binary.version}</artifactId>
+			<version>${spark.version}</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- test dependencies -->
@@ -93,7 +101,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.scalatest</groupId>
-			<artifactId>scalatest_2.11</artifactId>
+			<artifactId>scalatest_${scala.binary.version}</artifactId>
 			<version>2.2.4</version>
 			<scope>test</scope>
 		</dependency>
@@ -102,29 +110,9 @@
 	<build>
 		<directory>target</directory>
 		<outputDirectory>target/classes</outputDirectory>
-		<finalName>${project.artifactId}-${spark.version.parsed}_${scala.version.parsed}-${project.version}</finalName>
+		<finalName>${project.artifactId}-${spark.binary.version}_${scala.binary.version}-${project.version}</finalName>
 		<testOutputDirectory>target/test-classes</testOutputDirectory>
 		<plugins>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>1.8</version>
-				<executions>
-					<execution>
-						<id>regex-spark-property</id>
-						<goals>
-							<goal>regex-property</goal>
-						</goals>
-						<configuration>
-							<name>spark.version.parsed</name>
-							<value>${spark.version}</value>
-							<regex>(\d+\.\d+)\.\d+</regex>
-							<replacement>$1</replacement>
-							<failIfNoMatch>true</failIfNoMatch>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 			<!-- For incremental compilation -->
 			<plugin>
 				<groupId>net.alchim31.maven</groupId>
@@ -132,8 +120,16 @@
 				<version>3.2.2</version>
 				<executions>
 					<execution>
+						<id>scala-compile-first</id>
+						<phase>process-resources</phase>
 						<goals>
 							<goal>compile</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>scala-test-compile-first</id>
+						<phase>process-test-resources</phase>
+						<goals>
 							<goal>testCompile</goal>
 						</goals>
 					</execution>
@@ -151,20 +147,23 @@
 					<jvmArgs>
 						<jvmArg>-Xms1024m</jvmArg>
 						<jvmArg>-Xmx1024m</jvmArg>
+						<jvmArg>-XX:PermSize=${PermGen}</jvmArg>
+						<jvmArg>-XX:MaxPermSize=${MaxPermGen}</jvmArg>
+						<jvmArg>-XX:ReservedCodeCacheSize=${CodeCacheSize}</jvmArg>
 					</jvmArgs>
 				</configuration>
 			</plugin>
-			<!-- hivemall-spark_2.11-xx.jar -->
+			<!-- hivemall-spark_xx-xx.jar -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>2.5</version>
 				<configuration>
-					<finalName>${project.artifactId}-${spark.version.parsed}_${scala.version.parsed}-${project.version}</finalName>
+					<finalName>${project.artifactId}-${spark.binary.version}_${scala.binary.version}-${project.version}</finalName>
 					<outputDirectory>${project.parent.build.directory}</outputDirectory>
 				</configuration>
 			</plugin>
-			<!-- hivemall-spark_2.11-xx-with-dependencies.jar including minimum dependencies -->
+			<!-- hivemall-spark_xx-xx-with-dependencies.jar including minimum dependencies -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
@@ -177,7 +176,7 @@
 							<goal>shade</goal>
 						</goals>
 						<configuration>
-							<finalName>${project.artifactId}-${spark.version.parsed}_${scala.version.parsed}-${project.version}-with-dependencies</finalName>
+							<finalName>${project.artifactId}-${spark.binary.version}_${scala.binary.version}-${project.version}-with-dependencies</finalName>
 							<outputDirectory>${project.parent.build.directory}</outputDirectory>
 							<minimizeJar>false</minimizeJar>
 							<createDependencyReducedPom>false</createDependencyReducedPom>
@@ -197,7 +196,7 @@
 					</execution>
 				</executions>
 			</plugin>
-			<!-- disable surefire -->
+			<!-- disable surefire because there is no java test -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
@@ -214,8 +213,28 @@
 				<configuration>
 					<reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
 					<junitxml>.</junitxml>
-					<filereports>WDF TestSuite.txt</filereports>
-					<argLine>-Xms256m -Xmx1024m -XX:MaxPermSize=1024m -XX:+CMSClassUnloadingEnabled</argLine>
+					<filereports>SparkTestSuite.txt</filereports>
+					<argLine>-Xmx1024m -XX:MaxPermSize=${MaxPermGen} -XX:ReservedCodeCacheSize=${CodeCacheSize}</argLine>
+					<stderr/>
+					<environmentVariables>
+						<SPARK_PREPEND_CLASSES>1</SPARK_PREPEND_CLASSES>
+						<SPARK_SCALA_VERSION>${scala.binary.version}</SPARK_SCALA_VERSION>
+						<SPARK_TESTING>1</SPARK_TESTING>
+						<JAVA_HOME>${env.JAVA_HOME}</JAVA_HOME>
+					</environmentVariables>
+					<systemProperties>
+						<log4j.configuration>file:src/test/resources/log4j.properties</log4j.configuration>
+						<derby.system.durability>test</derby.system.durability>
+						<java.awt.headless>true</java.awt.headless>
+						<java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>
+						<spark.testing>1</spark.testing>
+						<spark.ui.enabled>false</spark.ui.enabled>
+						<spark.ui.showConsoleProgress>false</spark.ui.showConsoleProgress>
+						<spark.unsafe.exceptionOnMemoryLeak>true</spark.unsafe.exceptionOnMemoryLeak>
+						<!-- Needed by sql/hive tests. -->
+						<test.src.tables>__not_used__</test.src.tables>
+					</systemProperties>
+					<tagsToExclude>${test.exclude.tags}</tagsToExclude>
 				</configuration>
 				<executions>
 					<execution>

--- a/spark/spark-common/pom.xml
+++ b/spark/spark-common/pom.xml
@@ -14,8 +14,9 @@
 	<packaging>jar</packaging>
 
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<scala.version>2.11.8</scala.version>
+		<PermGen>64m</PermGen>
+		<MaxPermGen>1024m</MaxPermGen>
+		<CodeCacheSize>512m</CodeCacheSize>
 	</properties>
 
 	<dependencies>
@@ -26,26 +27,27 @@
 			<version>${project.version}</version>
 			<scope>compile</scope>
 		</dependency>
+
+		<!-- other provided dependencies -->
 		<dependency>
 			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-sql_2.11</artifactId>
+			<artifactId>spark-sql_${scala.binary.version}</artifactId>
 			<version>${spark.version}</version>
-			<scope>compile</scope>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-hive_2.11</artifactId>
+			<artifactId>spark-hive_${scala.binary.version}</artifactId>
 			<version>${spark.version}</version>
-			<scope>compile</scope>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-streaming_2.11</artifactId>
+			<artifactId>spark-streaming_${scala.binary.version}</artifactId>
 			<version>${spark.version}</version>
-			<scope>compile</scope>
+			<scope>provided</scope>
 		</dependency>
 
-		<!-- other third-party dependencies -->
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-core</artifactId>
@@ -73,8 +75,16 @@
 				<version>3.2.2</version>
 				<executions>
 					<execution>
+						<id>scala-compile-first</id>
+						<phase>process-resources</phase>
 						<goals>
 							<goal>compile</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>scala-test-compile-first</id>
+						<phase>process-test-resources</phase>
+						<goals>
 							<goal>testCompile</goal>
 						</goals>
 					</execution>
@@ -92,6 +102,9 @@
 					<jvmArgs>
 						<jvmArg>-Xms1024m</jvmArg>
 						<jvmArg>-Xmx1024m</jvmArg>
+						<jvmArg>-XX:PermSize=${PermGen}</jvmArg>
+						<jvmArg>-XX:MaxPermSize=${MaxPermGen}</jvmArg>
+						<jvmArg>-XX:ReservedCodeCacheSize=${CodeCacheSize}</jvmArg>
 					</jvmArgs>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
This pr to brush up Spark-related `pom.xml`s
 - Fix wrong scopes in dependencies
 - Remove `build-helper-maven-plugin` because we hit errors in some conditions. This pr is to add new properties `scala.binary.version` and `spark.binary.version`. The properties are along with Spark ones.
 - Brush up options in `scala-maven-plugin` and `scalatest-maven-plugin`. The fixed options are almost same with Spark ones.