### PR TITLE
Inject the Hivemall aggregate functionality in RelationalGroupedDataset

### DIFF
--- a/spark/spark-2.0/src/main/scala/org/apache/spark/sql/hive/HivemallOps.scala
+++ b/spark/spark-2.0/src/main/scala/org/apache/spark/sql/hive/HivemallOps.scala
@@ -44,7 +44,6 @@ import org.apache.spark.unsafe.types.UTF8String
  * @groupname classifier
  * @groupname classifier.multiclass
  * @groupname xgboost
- * @groupname ensemble
  * @groupname knn.similarity
  * @groupname knn.distance
  * @groupname knn.lsh
@@ -638,39 +637,6 @@ final class HivemallOps(df: DataFrame) extends Logging {
       join = false, outer = false, None,
       Seq("rowid", "label", "probability").map(UnresolvedAttribute(_)),
       df.logicalPlan)
-  }
-
-  /**
-   * Groups the [[DataFrame]] using the specified columns, so we can run aggregation on them.
-   * See [[RelationalGroupedDatasetEx]] for all the available aggregate functions.
-   *
-   * TODO: This class bypasses the original GroupData
-   * so as to support user-defined aggregations.
-   * Need a more smart injection into existing DataFrame APIs.
-   *
-   * A list of added Hivemall UDAF:
-   *  - voted_avg
-   *  - weight_voted_avg
-   *  - argmin_kld
-   *  - max_label
-   *  - maxrow
-   *  - f1score
-   *  - mae
-   *  - mse
-   *  - rmse
-   *
-   * @groupname ensemble
-   */
-  @scala.annotation.varargs
-  def groupby(cols: Column*): RelationalGroupedDatasetEx = {
-    new RelationalGroupedDatasetEx(df, cols.map(_.expr), RelationalGroupedDataset.GroupByType)
-  }
-
-  @scala.annotation.varargs
-  def groupby(col1: String, cols: String*): RelationalGroupedDatasetEx = {
-    val colNames: Seq[String] = col1 +: cols
-    new RelationalGroupedDatasetEx(df, colNames.map(colName => df(colName).expr),
-      RelationalGroupedDataset.GroupByType)
   }
 
   /**

--- a/spark/spark-2.0/src/test/scala/org/apache/spark/sql/hive/ModelMixingSuite.scala
+++ b/spark/spark-2.0/src/test/scala/org/apache/spark/sql/hive/ModelMixingSuite.scala
@@ -28,6 +28,7 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.feature.HivemallLabeledPoint
 import org.apache.spark.sql.functions.when
 import org.apache.spark.sql.hive.HivemallOps._
+import org.apache.spark.sql.hive.HivemallGroupedDataset._
 import org.apache.spark.sql.hive.HivemallUtils._
 import org.apache.spark.sql.hive.test.TestHive
 import org.apache.spark.sql.hive.test.TestHive.implicits._
@@ -159,9 +160,9 @@ final class ModelMixingSuite extends SparkFunSuite with BeforeAndAfter {
           Seq[Column](add_bias($"features"), $"label",
             s"-mix localhost:${assignedPort} -mix_session ${groupId} -mix_threshold 2 -mix_cancel"))
         if (!res.columns.contains("conv")) {
-          res.groupby("feature").agg("weight"->"avg")
+          res.groupBy("feature").agg("weight"->"avg")
         } else {
-          res.groupby("feature").argmin_kld("weight", "conv")
+          res.groupBy("feature").argmin_kld("weight", "conv")
         }
       }.as("feature", "weight")
 
@@ -178,13 +179,13 @@ final class ModelMixingSuite extends SparkFunSuite with BeforeAndAfter {
       val predict = testDf_exploded
         .join(model, testDf_exploded("feature") === model("feature"), "LEFT_OUTER")
         .select($"rowid", ($"weight" * $"value").as("value"))
-        .groupby("rowid").sum("value")
+        .groupBy("rowid").sum("value")
         .as("rowid", "predicted")
 
       // Evaluation
       val eval = predict
         .join(testDf, predict("rowid") === testDf("rowid"))
-        .groupby()
+        .groupBy()
         .agg(Map("target"->"avg", "predicted"->"avg"))
         .as("target", "predicted")
 
@@ -219,9 +220,9 @@ final class ModelMixingSuite extends SparkFunSuite with BeforeAndAfter {
           Seq[Column](add_bias($"features"), $"label",
             s"-mix localhost:${assignedPort} -mix_session ${groupId} -mix_threshold 2 -mix_cancel"))
         if (!res.columns.contains("conv")) {
-          res.groupby("feature").agg("weight"->"avg")
+          res.groupBy("feature").agg("weight"->"avg")
         } else {
-          res.groupby("feature").argmin_kld("weight", "conv")
+          res.groupBy("feature").argmin_kld("weight", "conv")
         }
       }.as("feature", "weight")
 
@@ -238,7 +239,7 @@ final class ModelMixingSuite extends SparkFunSuite with BeforeAndAfter {
       val predict = testDf_exploded
         .join(model, testDf_exploded("feature") === model("feature"), "LEFT_OUTER")
         .select($"rowid", ($"weight" * $"value").as("value"))
-        .groupby("rowid").sum("value")
+        .groupBy("rowid").sum("value")
         .select($"rowid", when(sigmoid($"sum(value)") > 0.50, 1.0).otherwise(0.0))
         .as("rowid", "predicted")
 

--- a/spark/spark-2.0/src/test/scala/org/apache/spark/sql/hive/XGBoostSuite.scala
+++ b/spark/spark-2.0/src/test/scala/org/apache/spark/sql/hive/XGBoostSuite.scala
@@ -22,6 +22,7 @@ import java.io.File
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.hive.HivemallOps._
+import org.apache.spark.sql.hive.HivemallGroupedDataset._
 import org.apache.spark.sql.hive.HivemallUtils._
 import org.apache.spark.sql.types._
 import org.apache.spark.test.VectorQueryTest
@@ -117,7 +118,7 @@ final class XGBoostSuite extends VectorQueryTest {
       val model = hiveContext.sparkSession.read.format(xgboost).load(tempDir)
       val predict = model.join(mllibTestDf)
         .xgboost_multiclass_predict($"rowid", $"features", $"model_id", $"pred_model")
-        .groupby("rowid").max_label("probability", "label")
+        .groupBy("rowid").max_label("probability", "label")
         .toDF("rowid", "predicted")
 
       val result = predict.join(mllibTestDf, predict("rowid") === mllibTestDf("rowid"), "INNER")

--- a/spark/spark-2.0/src/test/scala/org/apache/spark/streaming/HivemallFeatureOpsSuite.scala
+++ b/spark/spark-2.0/src/test/scala/org/apache/spark/streaming/HivemallFeatureOpsSuite.scala
@@ -110,7 +110,7 @@ final class HivemallFeatureOpsSuite extends HivemallFeatureQueryTest {
           )
           testDf.join(testModel, testDf("feature") === testModel("feature"), "LEFT_OUTER")
             .select($"rowid", ($"weight" * $"value").as("value"))
-            .groupby("rowid").sum("value")
+            .groupBy("rowid").sum("value")
             .as("rowid", "value")
             .select($"rowid", sigmoid($"value"))
         }


### PR DESCRIPTION
This pr is to remove weird `groupby` clauses in the spark module.
In the current version, `voted_avg()` is used like;
```
df.select(...).groupby.voted_avg()
```
This pr changes this in a Spark way.
```
df.select(...).groupBy.voted_avg()
```